### PR TITLE
Fix immediate deploy workflow failure

### DIFF
--- a/.github/workflows/auto-terminate.yml
+++ b/.github/workflows/auto-terminate.yml
@@ -236,7 +236,7 @@ jobs:
           const setupSuccess = '${{ steps.setup.outputs.setup_success }}';
           const initSuccess = '${{ steps.init.outputs.init_success }}';
           const alreadyTerminated = '${{ steps.init.outputs.already_terminated }}';
-          const importSuccess = '${{ steps.import.outputs.import_success }}';
+          const importSuccess = 'true'; // Import step removed
           const prNumber = '${{ steps.validate.outputs.pr_number }}';
           
           let message;

--- a/.github/workflows/auto-terminate.yml
+++ b/.github/workflows/auto-terminate.yml
@@ -178,7 +178,7 @@ jobs:
           exit 1
         fi
     
-    # No import needed - state file contains the deployment state automatically
+    # State file contains the deployment state automatically via DigitalOcean Spaces backend
     
     - name: Destroy deployment
       if: steps.health_check.outputs.should_terminate == 'true' && steps.init.outputs.init_success == 'true' && steps.init.outputs.already_terminated == 'false'
@@ -236,7 +236,7 @@ jobs:
           const setupSuccess = '${{ steps.setup.outputs.setup_success }}';
           const initSuccess = '${{ steps.init.outputs.init_success }}';
           const alreadyTerminated = '${{ steps.init.outputs.already_terminated }}';
-          const importSuccess = 'true'; // Import step removed
+          // State managed automatically via DigitalOcean Spaces backend
           const prNumber = '${{ steps.validate.outputs.pr_number }}';
           
           let message;

--- a/.github/workflows/auto-terminate.yml
+++ b/.github/workflows/auto-terminate.yml
@@ -256,9 +256,6 @@ jobs:
             } else if (initSuccess !== 'true') {
               failedStep = 'Initialize Terraform';
               errorMsg = 'terraform init failed';
-            } else if (importSuccess !== 'true') {
-              failedStep = 'Import deployment resources';
-              errorMsg = 'Failed to import app or database into Terraform state';
             } else {
               failedStep = 'Destroy deployment';
               errorMsg = 'terraform destroy failed - some resources may still exist';
@@ -281,7 +278,7 @@ jobs:
         echo "**App ID:** ${{ steps.validate.outputs.app_id }}" >> $GITHUB_STEP_SUMMARY
         echo "**Health Status:** ${{ steps.health_check.outputs.health_status }}" >> $GITHUB_STEP_SUMMARY
         echo "**Should Terminate:** ${{ steps.health_check.outputs.should_terminate }}" >> $GITHUB_STEP_SUMMARY
-        echo "**Termination Result:** ${{ steps.terminate.outputs.result }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Termination Result:** ${{ steps.destroy.outputs.destroy_success }}" >> $GITHUB_STEP_SUMMARY
         echo "**Completed At:** $(date -u)" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "*Environment wait timer prevented runner time waste during 30-minute delay*" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy Budget App to DigitalOcean
 
-on:
+"on":
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ['**']
@@ -27,27 +27,14 @@ env:
 jobs:
   go-checks:
     name: Go Checks
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.24'
-    
-    - name: Download dependencies
-      run: go mod download
-    
-    - name: Vet
-      run: go vet ./...
-    
-    - name: Build
-      run: go build -v ./...
-    
-    - name: Test
-      run: go test ./...
+    uses: densestvoid/workflows/.github/workflows/go-checks@main
+    with:
+      go-version: '1.24'
+      working-directory: '.'
+    secrets: inherit
+    permissions:
+      contents: read
+      actions: read
 
   deploy:
     name: Deploy to DigitalOcean

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy Budget App to DigitalOcean
 
-"on":
+on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ['**']
@@ -26,15 +26,7 @@ env:
 
 jobs:
   go-checks:
-    name: Go Checks
-    uses: densestvoid/workflows/.github/workflows/go-checks@main
-    with:
-      go-version: '1.24'
-      working-directory: '.'
-    secrets: inherit
-    permissions:
-      contents: read
-      actions: read
+    uses: densestvoid/workflows/.github/workflows/go-checks.yml@main
 
   deploy:
     name: Deploy to DigitalOcean

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,21 +256,29 @@ jobs:
             terraform plan -detailed-exitcode -out=tfplan
             plan_exit_code=$?
             
-            if [ $plan_exit_code -eq 0 ]; then
-              echo "✅ No changes needed - infrastructure is up to date"
-              echo "deploy_success=true" >> $GITHUB_OUTPUT
-            elif [ $plan_exit_code -eq 2 ]; then
+            echo "📋 Terraform plan exit code: $plan_exit_code"
+            echo "📋 Plan details:"
+            terraform show tfplan || echo "No plan file to show"
+            
+            # Check if plan file exists and has content
+            if [ -f tfplan ] && [ -s tfplan ]; then
+              echo "📋 Plan file exists and has content - changes detected"
               echo "🔧 Infrastructure changes detected - applying updates..."
               if terraform apply -auto-approve tfplan; then
                 echo "✅ Infrastructure updates applied successfully"
                 echo "deploy_success=true" >> $GITHUB_OUTPUT
+                echo "changes_applied=true" >> $GITHUB_OUTPUT
               else
                 echo "❌ Infrastructure updates failed"
                 echo "deploy_success=false" >> $GITHUB_OUTPUT
                 exit 1
               fi
+            elif [ $plan_exit_code -eq 0 ]; then
+              echo "✅ No changes needed - infrastructure is up to date"
+              echo "deploy_success=true" >> $GITHUB_OUTPUT
+              echo "changes_applied=false" >> $GITHUB_OUTPUT
             else
-              echo "❌ Terraform plan failed"
+              echo "❌ Terraform plan failed with exit code $plan_exit_code"
               echo "deploy_success=false" >> $GITHUB_OUTPUT
               exit 1
             fi
@@ -287,19 +295,28 @@ jobs:
           fi
         fi
         
-        # Always get outputs (they exist even if no changes applied)
+        # Always try to get outputs - they should exist if deployment was successful
         echo "📊 Getting deployment outputs..."
-        APP_URL=$(terraform output -raw app_url)
-        APP_ID=$(terraform output -raw app_id)
-        MIGRATION_APP_ID=$(terraform output -raw migration_app_id)
-        DB_HOST=$(terraform output -raw database_host)
-        TOTAL_COST=$(terraform output -raw estimated_total_cost)
         
-        echo "APP_URL=${APP_URL}" >> $GITHUB_ENV
-        echo "APP_ID=${APP_ID}" >> $GITHUB_ENV
-        echo "MIGRATION_APP_ID=${MIGRATION_APP_ID}" >> $GITHUB_ENV
-        echo "DB_HOST=${DB_HOST}" >> $GITHUB_ENV
-        echo "TOTAL_COST=${TOTAL_COST}" >> $GITHUB_ENV
+        # Try to get outputs, but don't fail if they don't exist
+        APP_URL=$(terraform output -raw app_url 2>/dev/null || echo "")
+        APP_ID=$(terraform output -raw app_id 2>/dev/null || echo "")
+        MIGRATION_APP_ID=$(terraform output -raw migration_app_id 2>/dev/null || echo "")
+        DB_HOST=$(terraform output -raw database_host 2>/dev/null || echo "")
+        TOTAL_COST=$(terraform output -raw estimated_total_cost 2>/dev/null || echo "")
+        
+        if [ -n "$APP_URL" ]; then
+          echo "APP_URL=${APP_URL}" >> $GITHUB_ENV
+          echo "APP_ID=${APP_ID}" >> $GITHUB_ENV
+          echo "MIGRATION_APP_ID=${MIGRATION_APP_ID}" >> $GITHUB_ENV
+          echo "DB_HOST=${DB_HOST}" >> $GITHUB_ENV
+          echo "TOTAL_COST=${TOTAL_COST}" >> $GITHUB_ENV
+          echo "✅ Successfully retrieved deployment outputs"
+        else
+          echo "⚠️ No outputs found - this may indicate an incomplete deployment"
+          echo "📋 Available outputs:"
+          terraform output || echo "No outputs available"
+        fi
     
     # Database readiness, migrations, and app deployment all handled by Terraform
     

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -390,8 +390,19 @@ jobs:
             '_Architecture: Database → Migration Container → Application Container_'
           ].join('\n');
 
+          // Handle both PR events and manual dispatch
+          let issueNumber;
+          if (context.issue && context.issue.number) {
+            issueNumber = context.issue.number;
+          } else if (context.event.inputs && context.event.inputs.pr_number) {
+            issueNumber = parseInt(context.event.inputs.pr_number);
+          } else {
+            console.log('No PR number available for commenting');
+            return;
+          }
+
           await github.rest.issues.createComment({
-            issue_number: context.issue.number,
+            issue_number: issueNumber,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: message

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,28 +116,6 @@ jobs:
           exit 1
         fi
     
-    - name: Cancel existing auto-terminate workflow
-      if: steps.terraform_init.outputs.is_redeployment == 'true'
-      run: |
-        echo "🛑 Canceling existing auto-terminate workflow for redeployment..."
-        
-        # Get running workflows for this repository
-        runs_response=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/${{ github.repository }}/actions/runs?status=queued,in_progress")
-        
-        # Find auto-terminate workflows for this app
-        # Note: This step was referencing a non-existent step, removing for now
-        
-        echo "$runs_response" | jq -r '.workflow_runs[] | select(.name == "Auto-Terminate Deployment") | .id' | \
-        while read run_id; do
-          echo "Canceling workflow run: $run_id"
-          curl -X POST \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/runs/$run_id/cancel"
-        done
-        
-        echo "✅ Existing auto-terminate workflows canceled"
-    
     - name: Set up Go
       uses: actions/setup-go@v4
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,27 @@ env:
 jobs:
   go-checks:
     name: Go Checks
-    uses: densestvoid/workflows/.github/workflows/go-checks@main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24'
+    
+    - name: Download dependencies
+      run: go mod download
+    
+    - name: Vet
+      run: go vet ./...
+    
+    - name: Build
+      run: go build -v ./...
+    
+    - name: Test
+      run: go test ./...
 
   deploy:
     name: Deploy to DigitalOcean
@@ -128,7 +147,7 @@ jobs:
           "https://api.github.com/repos/${{ github.repository }}/actions/runs?status=queued,in_progress")
         
         # Find auto-terminate workflows for this app
-        existing_app_id="${{ steps.check_existing.outputs.existing_app_id }}"
+        # Note: This step was referencing a non-existent step, removing for now
         
         echo "$runs_response" | jq -r '.workflow_runs[] | select(.name == "Auto-Terminate Deployment") | .id' | \
         while read run_id; do

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -390,19 +390,8 @@ jobs:
             '_Architecture: Database → Migration Container → Application Container_'
           ].join('\n');
 
-          // Handle both PR events and manual dispatch
-          let issueNumber;
-          if (context.issue && context.issue.number) {
-            issueNumber = context.issue.number;
-          } else if (context.event.inputs && context.event.inputs.pr_number) {
-            issueNumber = parseInt(context.event.inputs.pr_number);
-          } else {
-            console.log('No PR number available for commenting');
-            return;
-          }
-
           await github.rest.issues.createComment({
-            issue_number: issueNumber,
+            issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: message

--- a/data/models.go
+++ b/data/models.go
@@ -417,9 +417,10 @@ func (s *Storage) UpdateTransactionPayeeCategory(accountID, transactionID int, p
 
 // BulkInsertTransactions inserts multiple transactions (for CSV upload)
 func (s *Storage) BulkInsertTransactions(accountID int, txs []Transaction) error {
-	for _, t := range txs {
+	for i := range txs {
+		t := &txs[i]
 		// Apply rules to the transaction
-		modifiedTx, err := s.ApplyRulesToTransaction(accountID, &t)
+		modifiedTx, err := s.ApplyRulesToTransaction(accountID, t)
 		if err != nil {
 			return fmt.Errorf("failed to apply rules to transaction: %w", err)
 		}
@@ -794,7 +795,8 @@ func (s *Storage) ApplyRulesToTransaction(accountID int, tx *Transaction) (*Tran
 	// Rules are already sorted by priority DESC from GetRulesByAccount
 
 	// Apply rules in order
-	for _, rule := range rules {
+	for i := range rules {
+		rule := &rules[i]
 		if !rule.Active {
 			continue
 		}
@@ -847,7 +849,8 @@ func (s *Storage) ApplyRuleToAllTransactions(accountID int, rule *Rule) (int, er
 		return 0, fmt.Errorf("failed to get transactions: %w", err)
 	}
 	updated := 0
-	for _, tx := range txs {
+	for i := range txs {
+		tx := &txs[i]
 		// Check if all conditions match
 		allMatch := true
 		for _, cond := range rule.Conditions {

--- a/data/models.go
+++ b/data/models.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -357,14 +358,25 @@ func (s *Storage) CreateTransaction(accountID int, date time.Time, originalPayee
 	return &t, nil
 }
 
-// GetTransactionsByAccount retrieves all unreviewed transactions for an account
-func (s *Storage) GetTransactionsByAccount(accountID int) ([]Transaction, error) {
-	query := `
-		SELECT id, account_id, date, original_payee, payee, category_id, amount, reviewed, created_at, updated_at
-		FROM transactions
-		WHERE account_id = $1 AND reviewed = FALSE
-		ORDER BY date DESC, id DESC
-	`
+// getTransactionsByAccountWithFilter retrieves transactions for an account with optional reviewed filter
+func (s *Storage) getTransactionsByAccountWithFilter(accountID int, reviewedOnly bool) ([]Transaction, error) {
+	var query string
+	if reviewedOnly {
+		query = `
+			SELECT id, account_id, date, original_payee, payee, category_id, amount, reviewed, created_at, updated_at
+			FROM transactions
+			WHERE account_id = $1 AND reviewed = FALSE
+			ORDER BY date DESC, id DESC
+		`
+	} else {
+		query = `
+			SELECT id, account_id, date, original_payee, payee, category_id, amount, reviewed, created_at, updated_at
+			FROM transactions
+			WHERE account_id = $1
+			ORDER BY date DESC, id DESC
+		`
+	}
+
 	rows, err := s.db.Query(query, accountID)
 	if err != nil {
 		return nil, err
@@ -382,29 +394,14 @@ func (s *Storage) GetTransactionsByAccount(accountID int) ([]Transaction, error)
 	return txs, nil
 }
 
+// GetTransactionsByAccount retrieves all unreviewed transactions for an account
+func (s *Storage) GetTransactionsByAccount(accountID int) ([]Transaction, error) {
+	return s.getTransactionsByAccountWithFilter(accountID, true)
+}
+
 // GetAllTransactionsByAccount retrieves all transactions (both reviewed and unreviewed) for an account
 func (s *Storage) GetAllTransactionsByAccount(accountID int) ([]Transaction, error) {
-	query := `
-		SELECT id, account_id, date, original_payee, payee, category_id, amount, reviewed, created_at, updated_at
-		FROM transactions
-		WHERE account_id = $1
-		ORDER BY date DESC, id DESC
-	`
-	rows, err := s.db.Query(query, accountID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var txs []Transaction
-	for rows.Next() {
-		var t Transaction
-		if err := rows.Scan(&t.ID, &t.AccountID, &t.Date, &t.OriginalPayee, &t.Payee, &t.CategoryID, &t.Amount, &t.Reviewed, &t.CreatedAt, &t.UpdatedAt); err != nil {
-			return nil, err
-		}
-		txs = append(txs, t)
-	}
-	return txs, nil
+	return s.getTransactionsByAccountWithFilter(accountID, false)
 }
 
 // UpdateTransactionPayeeCategory updates a transaction's payee and category
@@ -560,7 +557,11 @@ func (s *Storage) CreateRule(accountID int, name string, newPayee *string, categ
 	if err != nil {
 		return nil, fmt.Errorf("failed to begin transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if err := tx.Rollback(); err != nil {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
 
 	// Insert the rule
 	var rule Rule
@@ -670,7 +671,11 @@ func (s *Storage) UpdateRule(accountID, ruleID int, name string, newPayee *strin
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if err := tx.Rollback(); err != nil {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
 
 	// Update the rule
 	query := `
@@ -722,7 +727,11 @@ func (s *Storage) DeleteRule(accountID, ruleID int) error {
 	if err != nil {
 		return fmt.Errorf("failed to begin transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() {
+		if err := tx.Rollback(); err != nil {
+			log.Printf("Error rolling back transaction: %v", err)
+		}
+	}()
 
 	// Delete conditions first (due to foreign key constraint)
 	_, err = tx.Exec("DELETE FROM rule_conditions WHERE rule_id = $1", ruleID)

--- a/data/models.go
+++ b/data/models.go
@@ -358,10 +358,10 @@ func (s *Storage) CreateTransaction(accountID int, date time.Time, originalPayee
 	return &t, nil
 }
 
-// getTransactionsByAccountWithFilter retrieves transactions for an account with optional reviewed filter
-func (s *Storage) getTransactionsByAccountWithFilter(accountID int, reviewedOnly bool) ([]Transaction, error) {
+// getTransactionsByAccountWithFilter retrieves transactions for an account with optional unreviewed filter
+func (s *Storage) getTransactionsByAccountWithFilter(accountID int, unreviewedOnly bool) ([]Transaction, error) {
 	var query string
-	if reviewedOnly {
+	if unreviewedOnly {
 		query = `
 			SELECT id, account_id, date, original_payee, payee, category_id, amount, reviewed, created_at, updated_at
 			FROM transactions

--- a/data/models.go
+++ b/data/models.go
@@ -81,7 +81,7 @@ type Rule struct {
 }
 
 // AmountDecimal returns the amount as a decimal string (e.g., 1234 -> "12.34")
-func (t Transaction) AmountDecimal() string {
+func (t *Transaction) AmountDecimal() string {
 	return fmt.Sprintf("%.2f", float64(t.Amount)/100.0)
 }
 
@@ -419,7 +419,7 @@ func (s *Storage) UpdateTransactionPayeeCategory(accountID, transactionID int, p
 func (s *Storage) BulkInsertTransactions(accountID int, txs []Transaction) error {
 	for _, t := range txs {
 		// Apply rules to the transaction
-		modifiedTx, err := s.ApplyRulesToTransaction(accountID, t)
+		modifiedTx, err := s.ApplyRulesToTransaction(accountID, &t)
 		if err != nil {
 			return fmt.Errorf("failed to apply rules to transaction: %w", err)
 		}
@@ -784,7 +784,7 @@ func (s *Storage) ToggleRuleActive(accountID, ruleID int) error {
 }
 
 // ApplyRulesToTransaction applies all active rules to a transaction and returns the modified transaction
-func (s *Storage) ApplyRulesToTransaction(accountID int, tx Transaction) (*Transaction, error) {
+func (s *Storage) ApplyRulesToTransaction(accountID int, tx *Transaction) (*Transaction, error) {
 	rules, err := s.GetRulesByAccount(accountID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rules: %w", err)
@@ -821,7 +821,7 @@ func (s *Storage) ApplyRulesToTransaction(accountID int, tx Transaction) (*Trans
 		}
 	}
 
-	return &tx, nil
+	return tx, nil
 }
 
 // conditionMatches checks if a condition matches the given payee text
@@ -841,7 +841,7 @@ func (s *Storage) conditionMatches(condition RuleCondition, payeeText string) bo
 }
 
 // ApplyRuleToAllTransactions applies a single rule to all existing transactions for an account and returns the number updated
-func (s *Storage) ApplyRuleToAllTransactions(accountID int, rule Rule) (int, error) {
+func (s *Storage) ApplyRuleToAllTransactions(accountID int, rule *Rule) (int, error) {
 	txs, err := s.GetAllTransactionsByAccount(accountID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get transactions: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.4
 
 require (
-	github.com/go-chi/chi/v5 v5.0.10
+	github.com/go-chi/chi/v5 v5.2.3
 	github.com/go-chi/cors v1.2.1
 	github.com/lib/pq v1.10.9
 	github.com/maragudk/gomponents v0.20.2
@@ -113,7 +113,7 @@ require (
 	github.com/go-toolsmith/astp v1.1.0 // indirect
 	github.com/go-toolsmith/strparse v1.1.0 // indirect
 	github.com/go-toolsmith/typep v1.1.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,8 @@ github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
 github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
 github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
+github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
 github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-critic/go-critic v0.12.0 h1:iLosHZuye812wnkEz1Xu3aBwn5ocCPfc9yqmFG9pa6w=
@@ -350,6 +352,8 @@ github.com/go-toolsmith/typep v1.1.0 h1:fIRYDyF+JywLfqzyhdiHzRop/GQDxxNhLGQ6gFUN
 github.com/go-toolsmith/typep v1.1.0/go.mod h1:fVIw+7zjdsMxDA3ITWnH1yOiw1rnTQKCsF/sk2H/qig=
 github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
 github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
+github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUWY=
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobuffalo/flect v1.0.3 h1:xeWBM2nui+qnVvNM4S3foBhCAL2XgPU+a7FdpelbTq4=

--- a/server/auth.go
+++ b/server/auth.go
@@ -10,6 +10,13 @@ import (
 	"time"
 )
 
+// Context key types to avoid collisions
+type contextKey string
+
+const (
+	accountKey contextKey = "account"
+)
+
 // AuthHandler handles authentication-related requests
 type AuthHandler struct {
 	store *data.Storage
@@ -41,7 +48,11 @@ type AuthResponse struct {
 
 // RegisterPage handles the registration page display
 func (h *AuthHandler) RegisterPage(w http.ResponseWriter, r *http.Request) {
-	templates.BaseLayoutWithAuth("Register - Budget App", false, templates.RegisterPage()).Render(w)
+	if err := templates.BaseLayoutWithAuth("Register - Budget App", false, templates.RegisterPage()).Render(w); err != nil {
+		log.Printf("Error rendering register page: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
 }
 
 // Register handles user registration from form submission
@@ -152,7 +163,9 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie("session_token")
 	if err == nil && cookie.Value != "" {
 		// Delete session from database
-		h.store.DeleteSession(cookie.Value)
+		if err := h.store.DeleteSession(cookie.Value); err != nil {
+			log.Printf("Error deleting session: %v", err)
+		}
 	}
 
 	// Clear cookie
@@ -175,7 +188,11 @@ func (h *AuthHandler) GetCurrentUser(w http.ResponseWriter, r *http.Request) {
 	account := r.Context().Value("account").(*data.Account)
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(account)
+	if err := json.NewEncoder(w).Encode(account); err != nil {
+		log.Printf("Error encoding account to JSON: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
 }
 
 // AuthMiddleware authenticates requests using session tokens
@@ -201,7 +218,7 @@ func (h *AuthHandler) AuthMiddleware(next http.Handler) http.Handler {
 
 		// Add account to request context
 		ctx := r.Context()
-		ctx = context.WithValue(ctx, "account", account)
+		ctx = context.WithValue(ctx, accountKey, account)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
@@ -227,7 +244,7 @@ func (h *AuthHandler) OptionalAuthMiddleware(next http.Handler) http.Handler {
 				log.Printf("Found authenticated account: %s (%s)", account.Name, account.Email)
 				// Add account to request context
 				ctx := r.Context()
-				ctx = context.WithValue(ctx, "account", account)
+				ctx = context.WithValue(ctx, accountKey, account)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -258,7 +275,7 @@ func (h *AuthHandler) AuthRequiredMiddleware(next http.Handler) http.Handler {
 
 		// Add account to request context
 		ctx := r.Context()
-		ctx = context.WithValue(ctx, "account", account)
+		ctx = context.WithValue(ctx, accountKey, account)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -228,19 +228,21 @@ func (h *AuthHandler) OptionalAuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Get session token from cookie
 		cookie, err := r.Cookie("session_token")
-		if err != nil {
+		switch {
+		case err != nil:
 			log.Printf("No session cookie found: %v", err)
-		} else if cookie.Value == "" {
+		case cookie.Value == "":
 			log.Printf("Session cookie is empty")
-		} else {
+		default:
 			log.Printf("Found session token: %s", cookie.Value[:10]+"...")
 			// Get account from session
 			account, err := h.store.GetAccountBySession(cookie.Value)
-			if err != nil {
+			switch {
+			case err != nil:
 				log.Printf("Error getting account from session: %v", err)
-			} else if account == nil {
+			case account == nil:
 				log.Printf("No account found for session token")
-			} else {
+			default:
 				log.Printf("Found authenticated account: %s (%s)", account.Name, account.Email)
 				// Add account to request context
 				ctx := r.Context()

--- a/server/server.go
+++ b/server/server.go
@@ -1291,7 +1291,6 @@ func parseCSVFile(r *http.Request) ([][]string, error) {
 // validateCSVHeaders validates CSV headers and returns column indices
 func validateCSVHeaders(header []string) (map[string]int, error) {
 	required := map[string]bool{"date": false, "payee": false, "amount": false}
-	unrecognized := []string{}
 	colIdx := map[string]int{}
 
 	for i, col := range header {
@@ -1307,7 +1306,7 @@ func validateCSVHeaders(header []string) (map[string]int, error) {
 			required["amount"] = true
 			colIdx["amount"] = i
 		default:
-			unrecognized = append(unrecognized, col)
+			// Ignore unrecognized columns
 		}
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -742,7 +742,7 @@ func (s *Server) handleRuleCreationResponse(w http.ResponseWriter, r *http.Reque
 }
 
 // parseTransactionPatchData parses form data for transaction patching
-func parseTransactionPatchData(r *http.Request) (payee string, categoryID *int, reviewed bool, hasCategoryID bool, err error) {
+func parseTransactionPatchData(r *http.Request) (payee string, categoryID *int, reviewed, hasCategoryID bool, err error) {
 	if err := r.ParseForm(); err != nil {
 		return "", nil, false, false, err
 	}
@@ -766,7 +766,7 @@ func parseTransactionPatchData(r *http.Request) (payee string, categoryID *int, 
 }
 
 // updateTransactionFields updates transaction fields in the database
-func (s *Server) updateTransactionFields(accountID, transactionID int, payee string, categoryID *int, reviewed bool, hasCategoryID bool) error {
+func (s *Server) updateTransactionFields(accountID, transactionID int, payee string, categoryID *int, reviewed, hasCategoryID bool) error {
 	if payee != "" {
 		if err := s.store.UpdateTransactionPayee(accountID, transactionID, payee); err != nil {
 			return fmt.Errorf("failed to update payee: %w", err)
@@ -869,9 +869,10 @@ func (s *Server) handleTransactionUpdateSuccess(w http.ResponseWriter, txs []dat
 
 // findTransactionByID finds a transaction by ID in the list
 func (s *Server) findTransactionByID(txs []data.Transaction, transactionID int) *data.Transaction {
-	for _, t := range txs {
+	for i := range txs {
+		t := &txs[i]
 		if t.ID == transactionID {
-			return &t
+			return t
 		}
 	}
 	return nil
@@ -879,7 +880,8 @@ func (s *Server) findTransactionByID(txs []data.Transaction, transactionID int) 
 
 // isTransactionVisible checks if a transaction is still visible in the list
 func (s *Server) isTransactionVisible(txs []data.Transaction, transactionID int) bool {
-	for _, t := range txs {
+	for i := range txs {
+		t := &txs[i]
 		if t.ID == transactionID {
 			return true
 		}
@@ -982,7 +984,8 @@ func (s *Server) editPayeeInlineHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	var payee string
-	for _, t := range txns {
+	for i := range txns {
+		t := &txns[i]
 		if t.ID == transactionID {
 			payee = t.Payee
 			break
@@ -1015,7 +1018,8 @@ func (s *Server) editCategoryInlineHandler(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	var currentCatID *int
-	for _, t := range txns {
+	for i := range txns {
+		t := &txns[i]
 		if t.ID == transactionID {
 			currentCatID = t.CategoryID
 			break
@@ -1078,9 +1082,10 @@ func (s *Server) editTransactionModalHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	var transaction *data.Transaction
-	for _, t := range txs {
+	for i := range txs {
+		t := &txs[i]
 		if t.ID == transactionID {
-			transaction = &t
+			transaction = t
 			break
 		}
 	}
@@ -1423,8 +1428,7 @@ func parseTransactionFromRecord(record []string, colIdx map[string]int) (*data.T
 }
 
 // processUploadedTransactions processes the uploaded transactions and returns results
-func (s *Server) processUploadedTransactions(accountID int, records [][]string, colIdx map[string]int) (int, int, error) {
-	var newCount, duplicateCount int
+func (s *Server) processUploadedTransactions(accountID int, records [][]string, colIdx map[string]int) (newCount, duplicateCount int, err error) {
 	var txs []data.Transaction
 
 	// Parse all transactions first
@@ -1451,19 +1455,21 @@ func (s *Server) processUploadedTransactions(accountID int, records [][]string, 
 
 	// Create a map of existing transactions for quick lookup
 	existing := make(map[string]struct{})
-	for _, t := range existingTxs {
+	for i := range existingTxs {
+		t := &existingTxs[i]
 		key := fmt.Sprintf("%s|%s|%d", t.Date.Format("2006-01-02"), strings.ToLower(strings.TrimSpace(t.OriginalPayee)), t.Amount)
 		existing[key] = struct{}{}
 	}
 
 	// Filter out duplicates and prepare for bulk insert
 	var deduped []data.Transaction
-	for _, tx := range txs {
+	for i := range txs {
+		tx := &txs[i]
 		key := fmt.Sprintf("%s|%s|%d", tx.Date.Format("2006-01-02"), strings.ToLower(strings.TrimSpace(tx.OriginalPayee)), tx.Amount)
 		if _, found := existing[key]; found {
 			duplicateCount++
 		} else {
-			deduped = append(deduped, tx)
+			deduped = append(deduped, *tx)
 			existing[key] = struct{}{} // Prevent duplicates within the same upload
 		}
 	}
@@ -1646,9 +1652,10 @@ func (s *Server) toggleRuleHandler(w http.ResponseWriter, r *http.Request) {
 
 		// Find the specific rule that was toggled
 		var updatedRule *data.Rule
-		for _, rule := range rules {
+		for i := range rules {
+			rule := &rules[i]
 			if rule.ID == ruleID {
-				updatedRule = &rule
+				updatedRule = rule
 				break
 			}
 		}
@@ -1691,9 +1698,10 @@ func (s *Server) editRuleHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var rule *data.Rule
-	for _, r := range rules {
+	for i := range rules {
+		r := &rules[i]
 		if r.ID == ruleID {
-			rule = &r
+			rule = r
 			break
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -271,19 +271,35 @@ func (s *Server) categoriesPageHandler(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
+
+	// Get parent_id from query param
+	parentID := s.parseParentIDFromQuery(r)
+
+	// Get categories and render
 	categories, err := s.store.GetCategoriesByAccount(account.ID)
 	if err != nil {
 		http.Error(w, "Failed to load categories", http.StatusInternalServerError)
 		return
 	}
-	// Get parent_id from query param
-	var parentID *int
-	if pidStr := r.URL.Query().Get("parent_id"); pidStr != "" {
-		pid, err := strconv.Atoi(pidStr)
-		if err == nil {
-			parentID = &pid
-		}
+
+	s.renderCategoriesPage(w, r, categories, parentID)
+}
+
+// parseParentIDFromQuery parses parent_id from query parameters
+func (s *Server) parseParentIDFromQuery(r *http.Request) *int {
+	pidStr := r.URL.Query().Get("parent_id")
+	if pidStr == "" {
+		return nil
 	}
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return nil
+	}
+	return &pid
+}
+
+// renderCategoriesPage renders the categories page
+func (s *Server) renderCategoriesPage(w http.ResponseWriter, r *http.Request, categories []data.Category, parentID *int) {
 	// Find current parent category (if any)
 	var currentParent *data.Category
 	if parentID != nil {
@@ -294,6 +310,7 @@ func (s *Server) categoriesPageHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+
 	// Filter categories to only those whose ParentID == parentID
 	var visibleCategories []data.Category
 	for _, c := range categories {
@@ -301,6 +318,7 @@ func (s *Server) categoriesPageHandler(w http.ResponseWriter, r *http.Request) {
 			visibleCategories = append(visibleCategories, c)
 		}
 	}
+
 	// Build breadcrumb path
 	breadcrumb := buildCategoryBreadcrumbByID(categories, parentID)
 
@@ -331,85 +349,117 @@ func (s *Server) createCategoryHandler(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
+
+	// Parse form data using existing helper
+	name, parentID, err := parseCategoryFormData(r)
+	if err != nil {
 		http.Error(w, "Invalid form data", http.StatusBadRequest)
 		return
 	}
-	name := r.FormValue("name")
-	parentIDStr := r.FormValue("parent_id")
-	var parentID *int
-	if parentIDStr != "" {
-		pid, err := strconv.Atoi(parentIDStr)
-		if err == nil {
-			parentID = &pid
-		}
+
+	// Validate parent relationship
+	categories, err := s.store.GetCategoriesByAccount(account.ID)
+	if err != nil {
+		http.Error(w, "Failed to load categories", http.StatusInternalServerError)
+		return
 	}
 
-	_, err := s.store.CreateCategory(account.ID, name, parentID)
+	if err := validateCategoryParent(categories, 0, parentID); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	_, err = s.store.CreateCategory(account.ID, name, parentID)
 	if err != nil {
 		http.Error(w, "Failed to create category", http.StatusInternalServerError)
 		return
 	}
 
-	// Check if this is an HTMX request
-	if isHTMX(r) {
-		// Get the current parent_id from the form or referer to refresh the correct page
-		var currentParentID *int
-		if parentID != nil {
-			currentParentID = parentID
-		} else {
-			// If no parent specified, check referer for current directory
-			referer := r.Header.Get("Referer")
-			if referer != "" {
-				if u, err := url.Parse(referer); err == nil {
-					if pidStr := u.Query().Get("parent_id"); pidStr != "" {
-						if pid, err := strconv.Atoi(pidStr); err == nil {
-							currentParentID = &pid
-						}
-					}
-				}
-			}
-		}
+	s.handleCategoryCreationResponse(w, r, account.ID, parentID)
+}
 
-		// Get updated categories
-		categories, err := s.store.GetCategoriesByAccount(account.ID)
-		if err != nil {
-			http.Error(w, "Failed to load categories", http.StatusInternalServerError)
-			return
-		}
-
-		// Find current parent category (if any)
-		var currentParent *data.Category
-		if currentParentID != nil {
-			for _, c := range categories {
-				if c.ID == *currentParentID {
-					currentParent = &c
-					break
-				}
-			}
-		}
-
-		// Filter categories to only those whose ParentID == currentParentID
-		var visibleCategories []data.Category
-		for _, c := range categories {
-			if (c.ParentID == nil && currentParentID == nil) || (c.ParentID != nil && currentParentID != nil && *c.ParentID == *currentParentID) {
-				visibleCategories = append(visibleCategories, c)
-			}
-		}
-
-		// Build breadcrumb path
-		breadcrumb := buildCategoryBreadcrumbByID(categories, currentParentID)
-
-		// Return the updated directory navigation content
-		w.Header().Set("Content-Type", "text/html")
-		content := templates.CategoriesDirectoryNavigation(visibleCategories, categories, currentParent, breadcrumb)
-		if err := content.Render(w); err != nil {
-			log.Printf("Error rendering categories navigation: %v", err)
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
-		}
-	} else {
+// handleCategoryCreationResponse handles the response after creating a category
+func (s *Server) handleCategoryCreationResponse(w http.ResponseWriter, r *http.Request, accountID int, parentID *int) {
+	if !isHTMX(r) {
 		http.Redirect(w, r, "/categories/", http.StatusSeeOther)
+		return
+	}
+
+	// Get current parent ID from form or referer
+	currentParentID := s.getCurrentParentID(r, parentID)
+
+	// Get updated categories
+	categories, err := s.store.GetCategoriesByAccount(accountID)
+	if err != nil {
+		http.Error(w, "Failed to load categories", http.StatusInternalServerError)
+		return
+	}
+
+	// Render the updated directory navigation
+	s.renderCategoryDirectoryNavigation(w, categories, currentParentID)
+}
+
+// getCurrentParentID gets the current parent ID from form or referer
+func (s *Server) getCurrentParentID(r *http.Request, parentID *int) *int {
+	if parentID != nil {
+		return parentID
+	}
+
+	// If no parent specified, check referer for current directory
+	referer := r.Header.Get("Referer")
+	if referer == "" {
+		return nil
+	}
+
+	u, err := url.Parse(referer)
+	if err != nil {
+		return nil
+	}
+
+	pidStr := u.Query().Get("parent_id")
+	if pidStr == "" {
+		return nil
+	}
+
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return nil
+	}
+
+	return &pid
+}
+
+// renderCategoryDirectoryNavigation renders the category directory navigation
+func (s *Server) renderCategoryDirectoryNavigation(w http.ResponseWriter, categories []data.Category, currentParentID *int) {
+	// Find current parent category (if any)
+	var currentParent *data.Category
+	if currentParentID != nil {
+		for _, c := range categories {
+			if c.ID == *currentParentID {
+				currentParent = &c
+				break
+			}
+		}
+	}
+
+	// Filter categories to only those whose ParentID == currentParentID
+	var visibleCategories []data.Category
+	for _, c := range categories {
+		if (c.ParentID == nil && currentParentID == nil) || (c.ParentID != nil && currentParentID != nil && *c.ParentID == *currentParentID) {
+			visibleCategories = append(visibleCategories, c)
+		}
+	}
+
+	// Build breadcrumb path
+	breadcrumb := buildCategoryBreadcrumbByID(categories, currentParentID)
+
+	// Return the updated directory navigation content
+	w.Header().Set("Content-Type", "text/html")
+	content := templates.CategoriesDirectoryNavigation(visibleCategories, categories, currentParent, breadcrumb)
+	if err := content.Render(w); err != nil {
+		log.Printf("Error rendering categories navigation: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
 	}
 }
 
@@ -654,7 +704,7 @@ func parseRuleConditions(r *http.Request) []data.RuleCondition {
 func (s *Server) handleRuleCreationResponse(w http.ResponseWriter, r *http.Request, accountID int, createdRule *data.Rule, runImmediately bool) {
 	updatedCount := 0
 	if runImmediately && createdRule != nil {
-		count, err := s.store.ApplyRuleToAllTransactions(accountID, *createdRule)
+		count, err := s.store.ApplyRuleToAllTransactions(accountID, createdRule)
 		if err == nil {
 			updatedCount = count
 		}
@@ -746,69 +796,68 @@ func (s *Server) handleTransactionPatchResponse(w http.ResponseWriter, r *http.R
 	}
 
 	// Fetch updated transaction list and categories for rendering
-	txs, err := s.store.GetTransactionsByAccount(accountID)
+	txs, cats, err := s.getTransactionsAndCategories(accountID)
 	if err != nil {
-		http.Error(w, "Failed to load transactions", http.StatusInternalServerError)
-		return
-	}
-	cats, err := s.store.GetCategoriesByAccount(accountID)
-	if err != nil {
-		http.Error(w, "Failed to load categories", http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "text/html")
 	if updateErr != nil {
-		// Find the specific transaction for error display
-		var updatedTx *data.Transaction
-		for _, t := range txs {
-			if t.ID == transactionID {
-				updatedTx = &t
-				break
-			}
-		}
-		if updatedTx == nil {
-			// If transaction not found in list, it might have been reviewed and hidden
-			// In this case, just return the updated list
-			if err := templates.RenderTransactionListWithSelectableCards(w, txs, cats); err != nil {
-				log.Printf("Error rendering transaction list: %v", err)
-				http.Error(w, "Internal server error", http.StatusInternalServerError)
-				return
-			}
-			return
-		}
-		// Render the modal with the error message
-		w.WriteHeader(http.StatusBadRequest)
-		if err := templates.TransactionCardWithModalSelectable(*updatedTx, cats, "Failed to update transaction: "+updateErr.Error()).Render(w); err != nil {
-			log.Printf("Error rendering transaction card: %v", err)
+		s.handleTransactionUpdateError(w, txs, cats, transactionID, updateErr)
+		return
+	}
+
+	s.handleTransactionUpdateSuccess(w, txs, cats, transactionID)
+}
+
+// getTransactionsAndCategories fetches transactions and categories for an account
+func (s *Server) getTransactionsAndCategories(accountID int) ([]data.Transaction, []data.Category, error) {
+	txs, err := s.store.GetTransactionsByAccount(accountID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load transactions")
+	}
+	cats, err := s.store.GetCategoriesByAccount(accountID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to load categories")
+	}
+	return txs, cats, nil
+}
+
+// handleTransactionUpdateError handles the response when transaction update fails
+func (s *Server) handleTransactionUpdateError(w http.ResponseWriter, txs []data.Transaction, cats []data.Category, transactionID int, updateErr error) {
+	updatedTx := s.findTransactionByID(txs, transactionID)
+	if updatedTx == nil {
+		// If transaction not found in list, it might have been reviewed and hidden
+		// In this case, just return the updated list
+		if err := templates.RenderTransactionListWithSelectableCards(w, txs, cats); err != nil {
+			log.Printf("Error rendering transaction list: %v", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 		return
 	}
-
-	// Check if the transaction was marked as reviewed and should be hidden
-	var transactionStillVisible bool
-	for _, t := range txs {
-		if t.ID == transactionID {
-			transactionStillVisible = true
-			break
-		}
+	// Render the modal with the error message
+	w.WriteHeader(http.StatusBadRequest)
+	if err := templates.TransactionCardWithModalSelectable(updatedTx, cats, "Failed to update transaction: "+updateErr.Error()).Render(w); err != nil {
+		log.Printf("Error rendering transaction card: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
 	}
+}
 
+// handleTransactionUpdateSuccess handles the response when transaction update succeeds
+func (s *Server) handleTransactionUpdateSuccess(w http.ResponseWriter, txs []data.Transaction, cats []data.Category, transactionID int) {
+	transactionStillVisible := s.isTransactionVisible(txs, transactionID)
 	if transactionStillVisible {
 		// Transaction is still visible, return just the updated card
-		var updatedTx *data.Transaction
-		for _, t := range txs {
-			if t.ID == transactionID {
-				updatedTx = &t
-				break
+		updatedTx := s.findTransactionByID(txs, transactionID)
+		if updatedTx != nil {
+			if err := templates.TransactionCardWithModalSelectable(updatedTx, cats, "").Render(w); err != nil {
+				log.Printf("Error rendering transaction card: %v", err)
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
 			}
-		}
-		if err := templates.TransactionCardWithModalSelectable(*updatedTx, cats, "").Render(w); err != nil {
-			log.Printf("Error rendering transaction card: %v", err)
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
 		}
 	} else {
 		// Transaction was marked as reviewed and is now hidden, return empty content to remove the card
@@ -816,6 +865,26 @@ func (s *Server) handleTransactionPatchResponse(w http.ResponseWriter, r *http.R
 			log.Printf("Error writing response: %v", err)
 		}
 	}
+}
+
+// findTransactionByID finds a transaction by ID in the list
+func (s *Server) findTransactionByID(txs []data.Transaction, transactionID int) *data.Transaction {
+	for _, t := range txs {
+		if t.ID == transactionID {
+			return &t
+		}
+	}
+	return nil
+}
+
+// isTransactionVisible checks if a transaction is still visible in the list
+func (s *Server) isTransactionVisible(txs []data.Transaction, transactionID int) bool {
+	for _, t := range txs {
+		if t.ID == transactionID {
+			return true
+		}
+	}
+	return false
 }
 
 // parseAmountToCents parses a decimal string to int cents
@@ -1245,7 +1314,7 @@ func (s *Server) renderUpdatedCategoryCard(w http.ResponseWriter, accountID, cat
 	}
 
 	w.Header().Set("Content-Type", "text/html")
-	card := templates.CategoryCardOnly(*updatedCategory, categories)
+	card := templates.CategoryCardOnly(updatedCategory, categories)
 	if err := card.Render(w); err != nil {
 		log.Printf("Error rendering category card: %v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -1480,87 +1549,45 @@ func (s *Server) updateRuleHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	idStr := chi.URLParam(r, "id")
-	ruleID, err := strconv.Atoi(idStr)
+
+	// Parse rule ID
+	ruleID, err := s.parseRuleID(r)
 	if err != nil {
 		http.Error(w, "Invalid rule ID", http.StatusBadRequest)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
+
+	// Parse form data
+	name, newPayee, categoryIDStr, priorityStr, err := parseRuleFormData(r)
+	if err != nil {
 		http.Error(w, "Invalid form data", http.StatusBadRequest)
 		return
 	}
 
-	name := r.FormValue("name")
-	newPayee := r.FormValue("new_payee")
-	categoryIDStr := r.FormValue("category_id")
-	priorityStr := r.FormValue("priority")
-
-	var newPayeePtr *string
-	if newPayee != "" {
-		newPayeePtr = &newPayee
+	// Create rule from form data
+	rule, err := s.createRuleFromFormData(account.ID, name, newPayee, categoryIDStr, priorityStr)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
-	var categoryID *int
-	if categoryIDStr != "" {
-		cid, err := strconv.Atoi(categoryIDStr)
-		if err == nil {
-			// Validate that the category belongs to the current account
-			categories, err := s.store.GetCategoriesByAccount(account.ID)
-			if err != nil {
-				http.Error(w, "Failed to load categories", http.StatusInternalServerError)
-				return
-			}
+	// Parse conditions
+	conditions := parseRuleConditions(r)
 
-			// Check if the category ID exists for this account
-			categoryExists := false
-			for _, cat := range categories {
-				if cat.ID == cid {
-					categoryExists = true
-					break
-				}
-			}
-
-			if categoryExists {
-				categoryID = &cid
-			} else {
-				// Category doesn't belong to this account, ignore it
-				categoryID = nil
-			}
-		}
-	}
-
-	priority := 0
-	if priorityStr != "" {
-		if p, err := strconv.Atoi(priorityStr); err == nil {
-			priority = p
-		}
-	}
-
-	// Parse conditions from form
-	var conditions []data.RuleCondition
-	conditionCount := 0
-	for {
-		operator := r.FormValue(fmt.Sprintf("conditions[%d][operator]", conditionCount))
-		value := r.FormValue(fmt.Sprintf("conditions[%d][value]", conditionCount))
-		if operator == "" || value == "" {
-			break
-		}
-		conditions = append(conditions, data.RuleCondition{
-			Field:    "payee", // Conditions are always applied to payee
-			Operator: operator,
-			Value:    value,
-		})
-		conditionCount++
-	}
-
-	err = s.store.UpdateRule(account.ID, ruleID, name, newPayeePtr, categoryID, priority, conditions)
+	// Update the rule
+	err = s.store.UpdateRule(account.ID, ruleID, rule.Name, rule.NewPayee, rule.CategoryID, rule.Priority, conditions)
 	if err != nil {
 		http.Error(w, "Failed to update rule", http.StatusInternalServerError)
 		return
 	}
 
 	s.renderRulesListResponse(w, r, account)
+}
+
+// parseRuleID parses rule ID from URL parameters
+func (s *Server) parseRuleID(r *http.Request) (int, error) {
+	idStr := chi.URLParam(r, "id")
+	return strconv.Atoi(idStr)
 }
 
 func (s *Server) deleteRuleHandler(w http.ResponseWriter, r *http.Request) {
@@ -1633,7 +1660,7 @@ func (s *Server) toggleRuleHandler(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Content-Type", "text/html")
 		// Return only the updated rule card
-		if err := templates.RuleCard(*updatedRule, categories).Render(w); err != nil {
+		if err := templates.RuleCard(updatedRule, categories).Render(w); err != nil {
 			log.Printf("Error rendering rule card: %v", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return

--- a/server/server.go
+++ b/server/server.go
@@ -164,6 +164,83 @@ func (s *Server) renderRulesListResponse(w http.ResponseWriter, r *http.Request,
 	}
 }
 
+// parseCategoryFormData parses form data for category operations
+func parseCategoryFormData(r *http.Request) (name string, parentID *int, err error) {
+	if err := r.ParseForm(); err != nil {
+		return "", nil, err
+	}
+	name = r.FormValue("name")
+	parentIDStr := r.FormValue("parent_id")
+	if parentIDStr != "" {
+		pid, err := strconv.Atoi(parentIDStr)
+		if err == nil {
+			parentID = &pid
+		}
+	}
+	return name, parentID, nil
+}
+
+// validateCategoryParent validates that a parent category exists and doesn't create cycles
+func validateCategoryParent(categories []data.Category, categoryID int, parentID *int) error {
+	if parentID == nil {
+		return nil // No parent is valid
+	}
+
+	// Check if parent exists
+	var parentExists bool
+	for _, cat := range categories {
+		if cat.ID == *parentID {
+			parentExists = true
+			break
+		}
+	}
+	if !parentExists {
+		return fmt.Errorf("parent category not found")
+	}
+
+	// Check for circular reference
+	if *parentID == categoryID {
+		return fmt.Errorf("category cannot be its own parent")
+	}
+
+	// Check if parent is a descendant of this category
+	descendants := getDescendants(categories, categoryID)
+	if descendants[*parentID] {
+		return fmt.Errorf("cannot set parent to a descendant category")
+	}
+
+	return nil
+}
+
+// getDescendants returns a set of all descendant category IDs (including the category itself)
+func getDescendants(categories []data.Category, categoryID int) map[int]bool {
+	descendants := make(map[int]bool)
+	descendants[categoryID] = true
+
+	// Build a map for quick lookups
+	catMap := make(map[int]*data.Category)
+	for i := range categories {
+		catMap[categories[i].ID] = &categories[i]
+	}
+
+	// Use a queue to traverse all descendants
+	queue := []int{categoryID}
+	for len(queue) > 0 {
+		currentID := queue[0]
+		queue = queue[1:]
+
+		// Find all children of the current category
+		for _, cat := range categories {
+			if cat.ParentID != nil && *cat.ParentID == currentID {
+				descendants[cat.ID] = true
+				queue = append(queue, cat.ID)
+			}
+		}
+	}
+
+	return descendants
+}
+
 func (s *Server) homeHandler(w http.ResponseWriter, r *http.Request) {
 	s.renderPageWithAuth(w, r, "Home - Budget App", templates.HomePage, "Home")
 }
@@ -435,222 +512,246 @@ func (s *Server) uploadTransactionsHandler(w http.ResponseWriter, r *http.Reques
 		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
 		return
 	}
-	if err := r.ParseMultipartForm(10 << 20); err != nil {
-		http.Error(w, "Failed to parse form", http.StatusBadRequest)
-		return
-	}
-	file, _, err := r.FormFile("csv")
+
+	// Parse CSV file
+	records, err := parseCSVFile(r)
 	if err != nil {
-		http.Error(w, "Failed to get uploaded file", http.StatusBadRequest)
+		s.handleCSVError(w, r, err.Error())
 		return
 	}
-	defer file.Close()
-	reader := csv.NewReader(file)
-	records, err := reader.ReadAll()
+
+	// Validate headers
+	colIdx, err := validateCSVHeaders(records[0])
 	if err != nil {
-		http.Error(w, "Failed to read CSV", http.StatusBadRequest)
+		s.handleCSVError(w, r, err.Error())
 		return
 	}
-	if len(records) == 0 {
-		http.Error(w, "CSV file is empty", http.StatusBadRequest)
-		return
-	}
-	header := records[0]
-	required := map[string]bool{"date": false, "payee": false, "amount": false}
-	unrecognized := []string{}
-	colIdx := map[string]int{}
-	for i, col := range header {
-		colNorm := strings.ToLower(strings.TrimSpace(col))
-		switch colNorm {
-		case "date", "payee", "amount":
-			required[colNorm] = true
-			colIdx[colNorm] = i
-		default:
-			unrecognized = append(unrecognized, col)
-		}
-	}
-	missing := []string{}
-	for k, v := range required {
-		if !v {
-			missing = append(missing, k)
-		}
-	}
-	if len(missing) > 0 || len(unrecognized) > 0 {
-		errMsg := "CSV error: "
-		if len(missing) > 0 {
-			errMsg += "Missing columns: " + strings.Join(missing, ", ")
-		}
-		if len(unrecognized) > 0 {
-			if len(missing) > 0 {
-				errMsg += ". "
-			}
-			errMsg += "Unrecognized columns: " + strings.Join(unrecognized, ", ")
-		}
-		if isHTMX(r) {
-			w.Header().Set("Content-Type", "text/html")
-			w.WriteHeader(http.StatusBadRequest)
-			if _, err := w.Write([]byte(`<div class="alert alert-danger" role="alert">` + errMsg + `</div>`)); err != nil {
-				log.Printf("Error writing error message: %v", err)
-			}
-			return
-		} else {
-			http.Error(w, errMsg, http.StatusBadRequest)
-			return
-		}
-	}
-	var txs []data.Transaction
-	for i, rec := range records[1:] {
-		if len(rec) < len(header) {
-			http.Error(w, "Row "+strconv.Itoa(i+2)+" is missing columns", http.StatusBadRequest)
-			return
-		}
-		dateStr := rec[colIdx["date"]]
-		payee := rec[colIdx["payee"]]
-		amountStr := rec[colIdx["amount"]]
-		date, err := time.Parse("2006-01-02", dateStr)
-		if err != nil {
-			// Try mm/dd/yyyy
-			date, err = time.Parse("01/02/2006", dateStr)
-			if err != nil {
-				http.Error(w, "Invalid date in row "+strconv.Itoa(i+2)+": "+dateStr, http.StatusBadRequest)
-				return
-			}
-		}
-		amountCents, err := parseAmountToCents(amountStr)
-		if err != nil {
-			http.Error(w, "Invalid amount in row "+strconv.Itoa(i+2)+": "+amountStr, http.StatusBadRequest)
-			return
-		}
-		txs = append(txs, data.Transaction{
-			AccountID:     account.ID,
-			Date:          date,
-			OriginalPayee: payee,
-			Payee:         payee,
-			Amount:        amountCents,
-		})
-	}
-	// Deduplicate: fetch all existing transactions for this account (including reviewed ones)
-	existingTxs, err := s.store.GetAllTransactionsByAccount(account.ID)
+
+	// Process transactions
+	newCount, duplicateCount, err := s.processUploadedTransactions(account.ID, records, colIdx)
 	if err != nil {
-		http.Error(w, "Failed to check for duplicates", http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	txKey := func(date time.Time, originalPayee string, amount int) string {
-		return date.Format("2006-01-02") + "|" + strings.ToLower(strings.TrimSpace(originalPayee)) + "|" + strconv.Itoa(amount)
-	}
-	existing := make(map[string]struct{})
-	for _, t := range existingTxs {
-		existing[txKey(t.Date, t.OriginalPayee, t.Amount)] = struct{}{}
-	}
-	var deduped []data.Transaction
-	for _, t := range txs {
-		key := txKey(t.Date, t.OriginalPayee, t.Amount)
-		if _, found := existing[key]; !found {
-			deduped = append(deduped, t)
-			existing[key] = struct{}{} // prevent duplicates within the same upload
-		}
-	}
-	if err := s.store.BulkInsertTransactions(account.ID, deduped); err != nil {
-		http.Error(w, "Failed to import transactions", http.StatusInternalServerError)
-		return
-	}
-	http.Redirect(w, r, "/transactions/", http.StatusSeeOther)
+
+	// Redirect with success message
+	http.Redirect(w, r, fmt.Sprintf("/transactions/?uploaded=%d&duplicates=%d", newCount, duplicateCount), http.StatusSeeOther)
 }
 
-// parseAmountToCents parses a decimal string to int cents
-func parseAmountToCents(s string) (int, error) {
-	s = strings.TrimSpace(s)
-	s = strings.ReplaceAll(s, ",", "") // Remove thousands separator if present
-	neg := false
-	if strings.HasPrefix(s, "-") {
-		neg = true
+// handleCSVError handles CSV parsing errors with appropriate response format
+func (s *Server) handleCSVError(w http.ResponseWriter, r *http.Request, errMsg string) {
+	if isHTMX(r) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusBadRequest)
+		if _, err := w.Write([]byte(`<div class="alert alert-danger" role="alert">` + errMsg + `</div>`)); err != nil {
+			log.Printf("Error writing error message: %v", err)
+		}
+	} else {
+		http.Error(w, errMsg, http.StatusBadRequest)
 	}
-	s = strings.TrimPrefix(s, "-")
-	s = strings.TrimPrefix(s, "+")
-	s = strings.TrimSpace(s)
-	s = strings.TrimPrefix(s, "$")
-	f, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0, err
-	}
-	cents := int(f * 100)
-	if neg {
-		cents = -cents
-	}
-	return cents, nil
 }
 
-func (s *Server) SetDB(db *sql.DB) {
-	s.db = db
-	s.store = data.NewStorage(db)
-}
-
-func (s *Server) Run() error {
-	log.Printf("Server starting on port %s", s.port)
-
-	// Create HTTP/2 server
-	h2s := &http2.Server{}
-	server := &http.Server{
-		Addr:              ":" + s.port,
-		Handler:           h2c.NewHandler(s.router, h2s),
-		ReadHeaderTimeout: 20 * time.Second, // Prevent Slowloris attacks
-	}
-
-	return server.ListenAndServe()
-}
-
-// PATCH handler for transactions
-func (s *Server) patchTransactionHandler(w http.ResponseWriter, r *http.Request) {
-	account, ok := r.Context().Value("account").(*data.Account)
-	if !ok || account == nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		return
-	}
-	idStr := chi.URLParam(r, "id")
-	transactionID, err := strconv.Atoi(idStr)
-	if err != nil {
-		http.Error(w, "Invalid transaction ID", http.StatusBadRequest)
-		return
-	}
+// parseRuleFormData parses form data for rule creation
+func parseRuleFormData(r *http.Request) (name, newPayee, categoryIDStr, priorityStr string, err error) {
 	if err := r.ParseForm(); err != nil {
-		http.Error(w, "Invalid form data", http.StatusBadRequest)
+		return "", "", "", "", err
+	}
+	return r.FormValue("name"), r.FormValue("new_payee"), r.FormValue("category_id"), r.FormValue("priority"), nil
+}
+
+// validateRuleCategory validates that a category belongs to the account
+func (s *Server) validateRuleCategory(accountID int, categoryIDStr string) (*int, error) {
+	if categoryIDStr == "" {
+		return nil, nil
+	}
+
+	categoryID, err := strconv.Atoi(categoryIDStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid category ID")
+	}
+
+	categories, err := s.store.GetCategoriesByAccount(accountID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load categories")
+	}
+
+	for _, cat := range categories {
+		if cat.ID == categoryID {
+			return &categoryID, nil
+		}
+	}
+
+	return nil, fmt.Errorf("category not found")
+}
+
+// parseRulePriority parses and validates rule priority
+func parseRulePriority(priorityStr string) (int, error) {
+	if priorityStr == "" {
+		return 0, nil
+	}
+
+	priority, err := strconv.Atoi(priorityStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid priority")
+	}
+
+	if priority < 0 || priority > 100 {
+		return 0, fmt.Errorf("priority must be between 0 and 100")
+	}
+
+	return priority, nil
+}
+
+// createRuleFromFormData creates a rule from form data
+func (s *Server) createRuleFromFormData(accountID int, name, newPayee, categoryIDStr, priorityStr string) (*data.Rule, error) {
+	var newPayeePtr *string
+	if newPayee != "" {
+		newPayeePtr = &newPayee
+	}
+
+	categoryID, err := s.validateRuleCategory(accountID, categoryIDStr)
+	if err != nil {
+		return nil, err
+	}
+
+	priority, err := parseRulePriority(priorityStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data.Rule{
+		AccountID:  accountID,
+		Name:       name,
+		NewPayee:   newPayeePtr,
+		CategoryID: categoryID,
+		Priority:   priority,
+	}, nil
+}
+
+// parseRuleConditions parses rule conditions from form data
+func parseRuleConditions(r *http.Request) []data.RuleCondition {
+	var conditions []data.RuleCondition
+	conditionCount := 0
+
+	for {
+		operator := r.FormValue(fmt.Sprintf("conditions[%d][operator]", conditionCount))
+		value := r.FormValue(fmt.Sprintf("conditions[%d][value]", conditionCount))
+		if operator == "" || value == "" {
+			break
+		}
+		conditions = append(conditions, data.RuleCondition{
+			Field:    "payee", // Conditions are always applied to payee
+			Operator: operator,
+			Value:    value,
+		})
+		conditionCount++
+	}
+
+	return conditions
+}
+
+// handleRuleCreationResponse handles the response after creating a rule
+func (s *Server) handleRuleCreationResponse(w http.ResponseWriter, r *http.Request, accountID int, createdRule *data.Rule, runImmediately bool) {
+	updatedCount := 0
+	if runImmediately && createdRule != nil {
+		count, err := s.store.ApplyRuleToAllTransactions(accountID, *createdRule)
+		if err == nil {
+			updatedCount = count
+		}
+	}
+
+	if !isHTMX(r) {
+		http.Redirect(w, r, "/rules/", http.StatusSeeOther)
 		return
 	}
-	payee := r.FormValue("payee")
+
+	// Return updated rules list with banner if needed
+	rules, err := s.store.GetRulesByAccount(accountID)
+	if err != nil {
+		http.Error(w, "Failed to load rules", http.StatusInternalServerError)
+		return
+	}
+	categories, err := s.store.GetCategoriesByAccount(accountID)
+	if err != nil {
+		http.Error(w, "Failed to load categories", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	if updatedCount > 0 {
+		banner := fmt.Sprintf(`<div id="rule-banner" class="alert alert-success position-fixed top-0 start-50 translate-middle-x mt-3" style="z-index:2000; min-width:300px; text-align:center;">Updated %d transactions</div><script>setTimeout(function(){ var b=document.getElementById('rule-banner'); if(b){b.remove();}}, 3500);</script>`, updatedCount)
+		if _, err := w.Write([]byte(banner)); err != nil {
+			log.Printf("Error writing rule banner: %v", err)
+		}
+	}
+	if err := templates.RenderRulesList(w, rules, categories); err != nil {
+		log.Printf("Error rendering rules list: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+}
+
+// parseTransactionPatchData parses form data for transaction patching
+func parseTransactionPatchData(r *http.Request) (payee string, categoryID *int, reviewed bool, hasCategoryID bool, err error) {
+	if err := r.ParseForm(); err != nil {
+		return "", nil, false, false, err
+	}
+
+	payee = r.FormValue("payee")
 	categoryIDStr := r.FormValue("category_id")
-	var categoryID *int
+	hasCategoryID = r.Form.Has("category_id")
+
 	if categoryIDStr != "" {
 		cid, err := strconv.Atoi(categoryIDStr)
 		if err == nil {
 			categoryID = &cid
 		}
-	} else if r.Form.Has("category_id") {
+	} else if hasCategoryID {
 		categoryID = nil // explicitly set to null if empty string is sent
 	}
 
-	reviewed := r.FormValue("reviewed") == "on"
+	reviewed = r.FormValue("reviewed") == "on"
 
-	// Try to update the transaction
-	var updateErr error
+	return payee, categoryID, reviewed, hasCategoryID, nil
+}
+
+// updateTransactionFields updates transaction fields in the database
+func (s *Server) updateTransactionFields(accountID, transactionID int, payee string, categoryID *int, reviewed bool, hasCategoryID bool) error {
 	if payee != "" {
-		updateErr = s.store.UpdateTransactionPayee(account.ID, transactionID, payee)
-	}
-	if r.Form.Has("category_id") {
-		if updateErr == nil { // Only try if previous update succeeded
-			updateErr = s.store.UpdateTransactionCategory(account.ID, transactionID, categoryID)
+		if err := s.store.UpdateTransactionPayee(accountID, transactionID, payee); err != nil {
+			return fmt.Errorf("failed to update payee: %w", err)
 		}
 	}
-	if updateErr == nil {
-		updateErr = s.store.UpdateTransactionReviewed(account.ID, transactionID, reviewed)
+
+	if categoryID != nil || hasCategoryID {
+		if err := s.store.UpdateTransactionCategory(accountID, transactionID, categoryID); err != nil {
+			return fmt.Errorf("failed to update category: %w", err)
+		}
+	}
+
+	if reviewed {
+		if err := s.store.MarkTransactionReviewed(accountID, transactionID); err != nil {
+			return fmt.Errorf("failed to mark as reviewed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// handleTransactionPatchResponse handles the response after patching a transaction
+func (s *Server) handleTransactionPatchResponse(w http.ResponseWriter, r *http.Request, accountID, transactionID int, updateErr error) {
+	if !isHTMX(r) {
+		http.Redirect(w, r, "/transactions/", http.StatusSeeOther)
+		return
 	}
 
 	// Fetch updated transaction list and categories for rendering
-	txs, err := s.store.GetTransactionsByAccount(account.ID)
+	txs, err := s.store.GetTransactionsByAccount(accountID)
 	if err != nil {
 		http.Error(w, "Failed to load transactions", http.StatusInternalServerError)
 		return
 	}
-	cats, err := s.store.GetCategoriesByAccount(account.ID)
+	cats, err := s.store.GetCategoriesByAccount(accountID)
 	if err != nil {
 		http.Error(w, "Failed to load categories", http.StatusInternalServerError)
 		return
@@ -715,6 +816,82 @@ func (s *Server) patchTransactionHandler(w http.ResponseWriter, r *http.Request)
 			log.Printf("Error writing response: %v", err)
 		}
 	}
+}
+
+// parseAmountToCents parses a decimal string to int cents
+func parseAmountToCents(s string) (int, error) {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, ",", "") // Remove thousands separator if present
+	neg := false
+	if strings.HasPrefix(s, "-") {
+		neg = true
+	}
+	s = strings.TrimPrefix(s, "-")
+	s = strings.TrimPrefix(s, "+")
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "$")
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, err
+	}
+	cents := int(f * 100)
+	if neg {
+		cents = -cents
+	}
+	return cents, nil
+}
+
+func (s *Server) SetDB(db *sql.DB) {
+	s.db = db
+	s.store = data.NewStorage(db)
+}
+
+func (s *Server) Run() error {
+	log.Printf("Server starting on port %s", s.port)
+
+	// Create HTTP/2 server
+	h2s := &http2.Server{}
+	server := &http.Server{
+		Addr:              ":" + s.port,
+		Handler:           h2c.NewHandler(s.router, h2s),
+		ReadHeaderTimeout: 20 * time.Second, // Prevent Slowloris attacks
+	}
+
+	return server.ListenAndServe()
+}
+
+// PATCH handler for transactions
+func (s *Server) patchTransactionHandler(w http.ResponseWriter, r *http.Request) {
+	account, ok := r.Context().Value("account").(*data.Account)
+	if !ok || account == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	transactionID, err := s.parseTransactionID(r)
+	if err != nil {
+		http.Error(w, "Invalid transaction ID", http.StatusBadRequest)
+		return
+	}
+
+	// Parse form data
+	payee, categoryID, reviewed, hasCategoryID, err := parseTransactionPatchData(r)
+	if err != nil {
+		http.Error(w, "Invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	// Update transaction fields
+	updateErr := s.updateTransactionFields(account.ID, transactionID, payee, categoryID, reviewed, hasCategoryID)
+
+	// Handle response
+	s.handleTransactionPatchResponse(w, r, account.ID, transactionID, updateErr)
+}
+
+// parseTransactionID extracts and parses the transaction ID from the request
+func (s *Server) parseTransactionID(r *http.Request) (int, error) {
+	idStr := chi.URLParam(r, "id")
+	return strconv.Atoi(idStr)
 }
 
 // GET /transactions/{id}/payee/edit returns an inline text input for payee
@@ -972,24 +1149,17 @@ func (s *Server) editCategoryHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	idStr := chi.URLParam(r, "id")
-	categoryID, err := strconv.Atoi(idStr)
+
+	categoryID, err := s.parseCategoryID(r)
 	if err != nil {
 		http.Error(w, "Invalid category ID", http.StatusBadRequest)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
+
+	name, parentID, err := parseCategoryFormData(r)
+	if err != nil {
 		http.Error(w, "Invalid form data", http.StatusBadRequest)
 		return
-	}
-	name := r.FormValue("name")
-	parentIDStr := r.FormValue("parent_id")
-	var parentID *int
-	if parentIDStr != "" {
-		pid, err := strconv.Atoi(parentIDStr)
-		if err == nil {
-			parentID = &pid
-		}
 	}
 
 	// Get the category before updating to check if parent changed
@@ -999,28 +1169,12 @@ func (s *Server) editCategoryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var oldParentID *int
-	for _, c := range categories {
-		if c.ID == categoryID {
-			oldParentID = c.ParentID
-			break
-		}
-	}
+	oldParentID := s.getCategoryParentID(categories, categoryID)
 
-	// Validate that parentID doesn't create a cyclic reference
-	if parentID != nil {
-		// Build a map for quick lookups
-		catMap := make(map[int]*data.Category)
-		for i := range categories {
-			catMap[categories[i].ID] = &categories[i]
-		}
-
-		// Check if the new parent is a descendant of the category being edited (would create cyclic reference)
-		descendants := s.store.GetDescendants(catMap, categoryID)
-		if descendants[*parentID] {
-			http.Error(w, "Cannot create cyclic reference", http.StatusBadRequest)
-			return
-		}
+	// Validate parent relationship
+	if err := validateCategoryParent(categories, categoryID, parentID); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	err = s.store.UpdateCategory(account.ID, categoryID, name, parentID)
@@ -1029,52 +1183,232 @@ func (s *Server) editCategoryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if this is an HTMX request
-	if isHTMX(r) {
-		// Check if parent changed - if so, remove the card, otherwise update it
-		parentChanged := (oldParentID == nil && parentID != nil) ||
-			(oldParentID != nil && parentID == nil) ||
-			(oldParentID != nil && parentID != nil && *oldParentID != *parentID)
+	s.handleCategoryUpdateResponse(w, r, account.ID, categoryID, oldParentID, parentID)
+}
 
-		if parentChanged {
-			// Parent changed, remove the card
-			w.Header().Set("Content-Type", "text/html")
-			if _, err := w.Write([]byte("")); err != nil {
-				log.Printf("Error writing response: %v", err)
-			}
-		} else {
-			// Parent didn't change, update the card
-			// Get updated categories
-			categories, err := s.store.GetCategoriesByAccount(account.ID)
-			if err != nil {
-				http.Error(w, "Failed to load categories", http.StatusInternalServerError)
-				return
-			}
+// parseCategoryID extracts and parses the category ID from the request
+func (s *Server) parseCategoryID(r *http.Request) (int, error) {
+	idStr := chi.URLParam(r, "id")
+	return strconv.Atoi(idStr)
+}
 
-			// Find the updated category
-			var updatedCategory *data.Category
-			for _, c := range categories {
-				if c.ID == categoryID {
-					updatedCategory = &c
-					break
-				}
-			}
+// getCategoryParentID finds the parent ID of a category
+func (s *Server) getCategoryParentID(categories []data.Category, categoryID int) *int {
+	for _, c := range categories {
+		if c.ID == categoryID {
+			return c.ParentID
+		}
+	}
+	return nil
+}
 
-			if updatedCategory != nil {
-				w.Header().Set("Content-Type", "text/html")
-				card := templates.CategoryCardOnly(*updatedCategory, categories)
-				if err := card.Render(w); err != nil {
-					log.Printf("Error rendering category card: %v", err)
-					http.Error(w, "Internal server error", http.StatusInternalServerError)
-					return
-				}
-			} else {
-				http.Error(w, "Category not found", http.StatusNotFound)
+// handleCategoryUpdateResponse handles the response after updating a category
+func (s *Server) handleCategoryUpdateResponse(w http.ResponseWriter, r *http.Request, accountID, categoryID int, oldParentID, parentID *int) {
+	if !isHTMX(r) {
+		http.Redirect(w, r, "/categories/", http.StatusSeeOther)
+		return
+	}
+
+	parentChanged := s.hasParentChanged(oldParentID, parentID)
+	if parentChanged {
+		// Parent changed, remove the card
+		w.Header().Set("Content-Type", "text/html")
+		if _, err := w.Write([]byte("")); err != nil {
+			log.Printf("Error writing response: %v", err)
+		}
+		return
+	}
+
+	// Parent didn't change, update the card
+	s.renderUpdatedCategoryCard(w, accountID, categoryID)
+}
+
+// hasParentChanged checks if the parent category has changed
+func (s *Server) hasParentChanged(oldParentID, parentID *int) bool {
+	return (oldParentID == nil && parentID != nil) ||
+		(oldParentID != nil && parentID == nil) ||
+		(oldParentID != nil && parentID != nil && *oldParentID != *parentID)
+}
+
+// renderUpdatedCategoryCard renders the updated category card
+func (s *Server) renderUpdatedCategoryCard(w http.ResponseWriter, accountID, categoryID int) {
+	categories, err := s.store.GetCategoriesByAccount(accountID)
+	if err != nil {
+		http.Error(w, "Failed to load categories", http.StatusInternalServerError)
+		return
+	}
+
+	updatedCategory := s.findCategoryByID(categories, categoryID)
+	if updatedCategory == nil {
+		http.Error(w, "Category not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	card := templates.CategoryCardOnly(*updatedCategory, categories)
+	if err := card.Render(w); err != nil {
+		log.Printf("Error rendering category card: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+}
+
+// findCategoryByID finds a category by its ID
+func (s *Server) findCategoryByID(categories []data.Category, categoryID int) *data.Category {
+	for _, c := range categories {
+		if c.ID == categoryID {
+			return &c
+		}
+	}
+	return nil
+}
+
+// parseCSVFile parses the uploaded CSV file and returns records
+func parseCSVFile(r *http.Request) ([][]string, error) {
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		return nil, fmt.Errorf("failed to parse form: %w", err)
+	}
+
+	file, _, err := r.FormFile("csv")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get uploaded file: %w", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CSV: %w", err)
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("CSV file is empty")
+	}
+
+	return records, nil
+}
+
+// validateCSVHeaders validates CSV headers and returns column indices
+func validateCSVHeaders(header []string) (map[string]int, error) {
+	required := map[string]bool{"date": false, "payee": false, "amount": false}
+	unrecognized := []string{}
+	colIdx := map[string]int{}
+
+	for i, col := range header {
+		col = strings.ToLower(strings.TrimSpace(col))
+		switch col {
+		case "date":
+			required["date"] = true
+			colIdx["date"] = i
+		case "payee", "description", "memo":
+			required["payee"] = true
+			colIdx["payee"] = i
+		case "amount", "debit", "credit":
+			required["amount"] = true
+			colIdx["amount"] = i
+		default:
+			unrecognized = append(unrecognized, col)
+		}
+	}
+
+	for field, found := range required {
+		if !found {
+			return nil, fmt.Errorf("missing required column: %s", field)
+		}
+	}
+
+	return colIdx, nil
+}
+
+// parseTransactionFromRecord parses a transaction from a CSV record
+func parseTransactionFromRecord(record []string, colIdx map[string]int) (*data.Transaction, error) {
+	dateStr := strings.TrimSpace(record[colIdx["date"]])
+	payee := strings.TrimSpace(record[colIdx["payee"]])
+	amountStr := strings.TrimSpace(record[colIdx["amount"]])
+
+	date, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		// Try other common date formats
+		formats := []string{"01/02/2006", "1/2/2006", "01-02-2006", "1-2-2006"}
+		for _, format := range formats {
+			if date, err = time.Parse(format, dateStr); err == nil {
+				break
 			}
 		}
-	} else {
-		http.Redirect(w, r, "/categories/", http.StatusSeeOther)
+		if err != nil {
+			return nil, fmt.Errorf("invalid date format: %s", dateStr)
+		}
 	}
+
+	amount, err := parseAmountToCents(amountStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid amount format: %s", amountStr)
+	}
+
+	return &data.Transaction{
+		Date:          date,
+		OriginalPayee: payee,
+		Payee:         payee,
+		Amount:        amount,
+		Reviewed:      false,
+	}, nil
+}
+
+// processUploadedTransactions processes the uploaded transactions and returns results
+func (s *Server) processUploadedTransactions(accountID int, records [][]string, colIdx map[string]int) (int, int, error) {
+	var newCount, duplicateCount int
+	var txs []data.Transaction
+
+	// Parse all transactions first
+	for i := 1; i < len(records); i++ { // Skip header
+		record := records[i]
+		if len(record) <= colIdx["amount"] {
+			continue // Skip incomplete rows
+		}
+
+		tx, err := parseTransactionFromRecord(record, colIdx)
+		if err != nil {
+			continue // Skip invalid rows
+		}
+
+		tx.AccountID = accountID
+		txs = append(txs, *tx)
+	}
+
+	// Get existing transactions for duplicate checking
+	existingTxs, err := s.store.GetAllTransactionsByAccount(accountID)
+	if err != nil {
+		return newCount, duplicateCount, fmt.Errorf("failed to check for duplicates: %w", err)
+	}
+
+	// Create a map of existing transactions for quick lookup
+	existing := make(map[string]struct{})
+	for _, t := range existingTxs {
+		key := fmt.Sprintf("%s|%s|%d", t.Date.Format("2006-01-02"), strings.ToLower(strings.TrimSpace(t.OriginalPayee)), t.Amount)
+		existing[key] = struct{}{}
+	}
+
+	// Filter out duplicates and prepare for bulk insert
+	var deduped []data.Transaction
+	for _, tx := range txs {
+		key := fmt.Sprintf("%s|%s|%d", tx.Date.Format("2006-01-02"), strings.ToLower(strings.TrimSpace(tx.OriginalPayee)), tx.Amount)
+		if _, found := existing[key]; found {
+			duplicateCount++
+		} else {
+			deduped = append(deduped, tx)
+			existing[key] = struct{}{} // Prevent duplicates within the same upload
+		}
+	}
+
+	// Bulk insert new transactions
+	if len(deduped) > 0 {
+		if err := s.store.BulkInsertTransactions(accountID, deduped); err != nil {
+			return newCount, duplicateCount, fmt.Errorf("failed to import transactions: %w", err)
+		}
+		newCount = len(deduped)
+	}
+
+	return newCount, duplicateCount, nil
 }
 
 // Rule management handlers
@@ -1109,117 +1443,36 @@ func (s *Server) createRuleHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	if err := r.ParseForm(); err != nil {
+
+	// Parse form data
+	name, newPayee, categoryIDStr, priorityStr, err := parseRuleFormData(r)
+	if err != nil {
 		http.Error(w, "Invalid form data", http.StatusBadRequest)
 		return
 	}
 
-	name := r.FormValue("name")
-	newPayee := r.FormValue("new_payee")
-	categoryIDStr := r.FormValue("category_id")
-	priorityStr := r.FormValue("priority")
-
-	var newPayeePtr *string
-	if newPayee != "" {
-		newPayeePtr = &newPayee
+	// Create rule from form data
+	rule, err := s.createRuleFromFormData(account.ID, name, newPayee, categoryIDStr, priorityStr)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
-	var categoryID *int
-	if categoryIDStr != "" {
-		cid, err := strconv.Atoi(categoryIDStr)
-		if err == nil {
-			// Validate that the category belongs to the current account
-			categories, err := s.store.GetCategoriesByAccount(account.ID)
-			if err != nil {
-				http.Error(w, "Failed to load categories", http.StatusInternalServerError)
-				return
-			}
+	// Parse conditions
+	conditions := parseRuleConditions(r)
 
-			// Check if the category ID exists for this account
-			categoryExists := false
-			for _, cat := range categories {
-				if cat.ID == cid {
-					categoryExists = true
-					break
-				}
-			}
-
-			if categoryExists {
-				categoryID = &cid
-			} else {
-				// Category doesn't belong to this account, ignore it
-				categoryID = nil
-			}
-		}
-	}
-
-	priority := 0
-	if priorityStr != "" {
-		if p, err := strconv.Atoi(priorityStr); err == nil {
-			priority = p
-		}
-	}
-
-	// Parse conditions from form
-	var conditions []data.RuleCondition
-	conditionCount := 0
-	for {
-		operator := r.FormValue(fmt.Sprintf("conditions[%d][operator]", conditionCount))
-		value := r.FormValue(fmt.Sprintf("conditions[%d][value]", conditionCount))
-		if operator == "" || value == "" {
-			break
-		}
-		conditions = append(conditions, data.RuleCondition{
-			Field:    "payee", // Conditions are always applied to payee
-			Operator: operator,
-			Value:    value,
-		})
-		conditionCount++
-	}
-
-	createdRule, err := s.store.CreateRule(account.ID, name, newPayeePtr, categoryID, priority, conditions)
+	// Create the rule in the database
+	createdRule, err := s.store.CreateRule(account.ID, rule.Name, rule.NewPayee, rule.CategoryID, rule.Priority, conditions)
 	if err != nil {
 		http.Error(w, "Failed to create rule", http.StatusInternalServerError)
 		return
 	}
 
 	// Check if run_immediately was requested
-	updatedCount := 0
-	if r.FormValue("run_immediately") == "on" || r.FormValue("run_immediately") == "true" {
-		if createdRule != nil {
-			count, err := s.store.ApplyRuleToAllTransactions(account.ID, *createdRule)
-			if err == nil {
-				updatedCount = count
-			}
-		}
-	}
+	runImmediately := r.FormValue("run_immediately") == "on" || r.FormValue("run_immediately") == "true"
 
-	if isHTMX(r) {
-		// Return updated rules list with banner if needed
-		rules, err := s.store.GetRulesByAccount(account.ID)
-		if err != nil {
-			http.Error(w, "Failed to load rules", http.StatusInternalServerError)
-			return
-		}
-		categories, err := s.store.GetCategoriesByAccount(account.ID)
-		if err != nil {
-			http.Error(w, "Failed to load categories", http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "text/html")
-		if updatedCount > 0 {
-			if _, err := w.Write([]byte(`<div id="rule-banner" class="alert alert-success position-fixed top-0 start-50 translate-middle-x mt-3" style="z-index:2000; min-width:300px; text-align:center;">Updated ` + strconv.Itoa(updatedCount) + ` transactions</div><script>setTimeout(function(){ var b=document.getElementById('rule-banner'); if(b){b.remove();}}, 3500);</script>`)); err != nil {
-				log.Printf("Error writing rule banner: %v", err)
-			}
-		}
-		if err := templates.RenderRulesList(w, rules, categories); err != nil {
-			log.Printf("Error rendering rules list: %v", err)
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
-		}
-	} else {
-		http.Redirect(w, r, "/rules/", http.StatusSeeOther)
-	}
+	// Handle response
+	s.handleRuleCreationResponse(w, r, account.ID, createdRule, runImmediately)
 }
 
 func (s *Server) updateRuleHandler(w http.ResponseWriter, r *http.Request) {

--- a/server/server.go
+++ b/server/server.go
@@ -123,34 +123,53 @@ func (s *Server) healthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) homeHandler(w http.ResponseWriter, r *http.Request) {
+// renderPageWithAuth is a helper function to render pages with authentication check
+func (s *Server) renderPageWithAuth(w http.ResponseWriter, r *http.Request, title string, pageFunc func() g.Node, handlerName string) {
 	var isAuthenticated bool
 	if account := r.Context().Value("account"); account != nil {
 		isAuthenticated = true
-		log.Printf("Home handler: User is authenticated - isAuthenticated=%t", isAuthenticated)
+		log.Printf("%s handler: User is authenticated - isAuthenticated=%t", handlerName, isAuthenticated)
 	} else {
-		log.Printf("Home handler: User is not authenticated - isAuthenticated=%t", isAuthenticated)
+		log.Printf("%s handler: User is not authenticated - isAuthenticated=%t", handlerName, isAuthenticated)
 	}
-	page := templates.HomePage()
-	if err := templates.BaseLayoutWithAuth("Home - Budget App", isAuthenticated, page).Render(w); err != nil {
-		log.Printf("Error rendering home page: %v", err)
+	page := pageFunc()
+	if err := templates.BaseLayoutWithAuth(title, isAuthenticated, page).Render(w); err != nil {
+		log.Printf("Error rendering %s page: %v", handlerName, err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 }
 
-func (s *Server) aboutHandler(w http.ResponseWriter, r *http.Request) {
-	var isAuthenticated bool
-	if account := r.Context().Value("account"); account != nil {
-		isAuthenticated = true
-		log.Printf("About handler: User is authenticated - isAuthenticated=%t", isAuthenticated)
+// renderRulesListResponse is a helper function to render rules list for HTMX responses
+func (s *Server) renderRulesListResponse(w http.ResponseWriter, r *http.Request, account *data.Account) {
+	if isHTMX(r) {
+		// Return updated rules list
+		rules, err := s.store.GetRulesByAccount(account.ID)
+		if err != nil {
+			http.Error(w, "Failed to load rules", http.StatusInternalServerError)
+			return
+		}
+		categories, err := s.store.GetCategoriesByAccount(account.ID)
+		if err != nil {
+			http.Error(w, "Failed to load categories", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		if err := templates.RenderRulesList(w, rules, categories); err != nil {
+			log.Printf("Error rendering rules list: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
 	} else {
-		log.Printf("About handler: User is not authenticated - isAuthenticated=%t", isAuthenticated)
+		http.Redirect(w, r, "/rules/", http.StatusSeeOther)
 	}
-	page := templates.AboutPage()
-	if err := templates.BaseLayoutWithAuth("About - Budget App", isAuthenticated, page).Render(w); err != nil {
-		log.Printf("Error rendering about page: %v", err)
-		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-	}
+}
+
+func (s *Server) homeHandler(w http.ResponseWriter, r *http.Request) {
+	s.renderPageWithAuth(w, r, "Home - Budget App", templates.HomePage, "Home")
+}
+
+func (s *Server) aboutHandler(w http.ResponseWriter, r *http.Request) {
+	s.renderPageWithAuth(w, r, "About - Budget App", templates.AboutPage, "About")
 }
 
 // Helper to build the breadcrumb path for a category by ID
@@ -213,11 +232,19 @@ func (s *Server) categoriesPageHandler(w http.ResponseWriter, r *http.Request) {
 		// Return only the directory navigation content for HTMX requests
 		w.Header().Set("Content-Type", "text/html")
 		content := templates.CategoriesDirectoryNavigation(visibleCategories, categories, currentParent, breadcrumb)
-		_ = content.Render(w)
+		if err := content.Render(w); err != nil {
+			log.Printf("Error rendering categories navigation: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
 	} else {
 		// Return full page for regular requests
 		page := templates.CategoriesDirectoryPage(visibleCategories, categories, currentParent, breadcrumb)
-		_ = templates.BaseLayoutWithAuth("Categories - Budget App", true, page).Render(w)
+		if err := templates.BaseLayoutWithAuth("Categories - Budget App", true, page).Render(w); err != nil {
+			log.Printf("Error rendering categories page: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
 	}
 }
 
@@ -299,43 +326,14 @@ func (s *Server) createCategoryHandler(w http.ResponseWriter, r *http.Request) {
 		// Return the updated directory navigation content
 		w.Header().Set("Content-Type", "text/html")
 		content := templates.CategoriesDirectoryNavigation(visibleCategories, categories, currentParent, breadcrumb)
-		_ = content.Render(w)
+		if err := content.Render(w); err != nil {
+			log.Printf("Error rendering categories navigation: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
 	} else {
 		http.Redirect(w, r, "/categories/", http.StatusSeeOther)
 	}
-}
-
-func (s *Server) updateCategoryHandler(w http.ResponseWriter, r *http.Request) {
-	account, ok := r.Context().Value("account").(*data.Account)
-	if !ok || account == nil {
-		http.Redirect(w, r, "/auth/login", http.StatusSeeOther)
-		return
-	}
-	idStr := chi.URLParam(r, "id")
-	categoryID, err := strconv.Atoi(idStr)
-	if err != nil {
-		http.Error(w, "Invalid category ID", http.StatusBadRequest)
-		return
-	}
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, "Invalid form data", http.StatusBadRequest)
-		return
-	}
-	name := r.FormValue("name")
-	parentIDStr := r.FormValue("parent_id")
-	var parentID *int
-	if parentIDStr != "" {
-		pid, err := strconv.Atoi(parentIDStr)
-		if err == nil {
-			parentID = &pid
-		}
-	}
-	err = s.store.UpdateCategory(account.ID, categoryID, name, parentID)
-	if err != nil {
-		http.Error(w, "Failed to update category", http.StatusInternalServerError)
-		return
-	}
-	http.Redirect(w, r, "/categories/", http.StatusSeeOther)
 }
 
 func (s *Server) deleteCategoryHandler(w http.ResponseWriter, r *http.Request) {
@@ -360,7 +358,9 @@ func (s *Server) deleteCategoryHandler(w http.ResponseWriter, r *http.Request) {
 	if isHTMX(r) {
 		// For delete, just return empty content to remove the card
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte(""))
+		if _, err := w.Write([]byte("")); err != nil {
+			log.Printf("Error writing response: %v", err)
+		}
 	} else {
 		http.Redirect(w, r, "/categories/", http.StatusSeeOther)
 	}
@@ -385,7 +385,11 @@ func (s *Server) transactionsPageHandler(w http.ResponseWriter, r *http.Request)
 	}
 	errMsg := r.URL.Query().Get("error")
 	page := templates.TransactionsPage(txs, cats, errMsg)
-	_ = templates.BaseLayoutWithAuth("Transactions - Budget App", true, page).Render(w)
+	if err := templates.BaseLayoutWithAuth("Transactions - Budget App", true, page).Render(w); err != nil {
+		log.Printf("Error rendering transactions page: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
 }
 
 func (s *Server) updateTransactionHandler(w http.ResponseWriter, r *http.Request) {
@@ -485,7 +489,9 @@ func (s *Server) uploadTransactionsHandler(w http.ResponseWriter, r *http.Reques
 		if isHTMX(r) {
 			w.Header().Set("Content-Type", "text/html")
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(`<div class="alert alert-danger" role="alert">` + errMsg + `</div>`))
+			if _, err := w.Write([]byte(`<div class="alert alert-danger" role="alert">` + errMsg + `</div>`)); err != nil {
+				log.Printf("Error writing error message: %v", err)
+			}
 			return
 		} else {
 			http.Error(w, errMsg, http.StatusBadRequest)
@@ -558,14 +564,11 @@ func parseAmountToCents(s string) (int, error) {
 	neg := false
 	if strings.HasPrefix(s, "-") {
 		neg = true
-		s = s[1:]
-	} else if strings.HasPrefix(s, "+") {
-		s = s[1:]
 	}
+	s = strings.TrimPrefix(s, "-")
+	s = strings.TrimPrefix(s, "+")
 	s = strings.TrimSpace(s)
-	if strings.HasPrefix(s, "$") {
-		s = s[1:]
-	}
+	s = strings.TrimPrefix(s, "$")
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		return 0, err
@@ -666,12 +669,20 @@ func (s *Server) patchTransactionHandler(w http.ResponseWriter, r *http.Request)
 		if updatedTx == nil {
 			// If transaction not found in list, it might have been reviewed and hidden
 			// In this case, just return the updated list
-			templates.RenderTransactionListWithSelectableCards(w, txs, cats)
+			if err := templates.RenderTransactionListWithSelectableCards(w, txs, cats); err != nil {
+				log.Printf("Error rendering transaction list: %v", err)
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
 			return
 		}
 		// Render the modal with the error message
 		w.WriteHeader(http.StatusBadRequest)
-		templates.TransactionCardWithModalSelectable(*updatedTx, cats, "Failed to update transaction: "+updateErr.Error()).Render(w)
+		if err := templates.TransactionCardWithModalSelectable(*updatedTx, cats, "Failed to update transaction: "+updateErr.Error()).Render(w); err != nil {
+			log.Printf("Error rendering transaction card: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
 		return
 	}
 
@@ -693,10 +704,16 @@ func (s *Server) patchTransactionHandler(w http.ResponseWriter, r *http.Request)
 				break
 			}
 		}
-		templates.TransactionCardWithModalSelectable(*updatedTx, cats, "").Render(w)
+		if err := templates.TransactionCardWithModalSelectable(*updatedTx, cats, "").Render(w); err != nil {
+			log.Printf("Error rendering transaction card: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
 	} else {
 		// Transaction was marked as reviewed and is now hidden, return empty content to remove the card
-		w.Write([]byte(""))
+		if _, err := w.Write([]byte("")); err != nil {
+			log.Printf("Error writing response: %v", err)
+		}
 	}
 }
 
@@ -726,9 +743,11 @@ func (s *Server) editPayeeInlineHandler(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	w.Header().Set("Content-Type", "text/html")
-	w.Write([]byte(`<form hx-patch="/transactions/` + idStr + `" hx-trigger="blur from:input, submit" hx-target="this" hx-swap="outerHTML" style="display:inline;">
+	if _, err := w.Write([]byte(`<form hx-patch="/transactions/` + idStr + `" hx-trigger="blur from:input, submit" hx-target="this" hx-swap="outerHTML" style="display:inline;">
 		<input type="text" name="payee" value="` + htmlEscape(payee) + `" class="form-control form-control-sm w-auto d-inline" autofocus onblur="this.form.requestSubmit()">
-	</form>`))
+</form>`)); err != nil {
+		log.Printf("Error writing form response: %v", err)
+	}
 }
 
 // GET /transactions/{id}/category/edit returns an inline select for category
@@ -777,7 +796,9 @@ func (s *Server) editCategoryInlineHandler(w http.ResponseWriter, r *http.Reques
 	}
 	sb.WriteString(`</select>`)
 	w.Header().Set("Content-Type", "text/html")
-	w.Write([]byte(sb.String()))
+	if _, err := w.Write([]byte(sb.String())); err != nil {
+		log.Printf("Error writing response: %v", err)
+	}
 }
 
 // Helper to escape HTML
@@ -832,7 +853,7 @@ func (s *Server) editTransactionModalHandler(w http.ResponseWriter, r *http.Requ
 	w.Header().Set("Content-Type", "text/html")
 
 	// Render the edit form
-	g.El("form",
+	form := g.El("form",
 		g.Attr("hx-patch", "/transactions/"+strconv.Itoa(transaction.ID)),
 		g.Attr("hx-target", "closest .mb-2"),
 		g.Attr("hx-swap", "outerHTML"),
@@ -879,7 +900,12 @@ func (s *Server) editTransactionModalHandler(w http.ResponseWriter, r *http.Requ
 			html.Button(html.Type("button"), html.Class("btn btn-secondary"), html.DataAttr("bs-dismiss", "modal"), g.Text("Cancel")),
 			html.Button(html.Type("submit"), html.Class("btn btn-primary"), g.Text("Save Changes")),
 		),
-	).Render(w)
+	)
+	if err := form.Render(w); err != nil {
+		log.Printf("Error rendering transaction edit form: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
 }
 
 // Handler to mark a transaction as reviewed
@@ -933,7 +959,11 @@ func (s *Server) markTransactionsReviewedHandler(w http.ResponseWriter, r *http.
 	}
 	w.Header().Set("Content-Type", "text/html")
 	// Render the transaction list with selectable cards
-	templates.RenderTransactionListWithSelectableCards(w, txs, cats)
+	if err := templates.RenderTransactionListWithSelectableCards(w, txs, cats); err != nil {
+		log.Printf("Error rendering transaction list: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
 }
 
 func (s *Server) editCategoryHandler(w http.ResponseWriter, r *http.Request) {
@@ -1009,7 +1039,9 @@ func (s *Server) editCategoryHandler(w http.ResponseWriter, r *http.Request) {
 		if parentChanged {
 			// Parent changed, remove the card
 			w.Header().Set("Content-Type", "text/html")
-			w.Write([]byte(""))
+			if _, err := w.Write([]byte("")); err != nil {
+				log.Printf("Error writing response: %v", err)
+			}
 		} else {
 			// Parent didn't change, update the card
 			// Get updated categories
@@ -1031,7 +1063,11 @@ func (s *Server) editCategoryHandler(w http.ResponseWriter, r *http.Request) {
 			if updatedCategory != nil {
 				w.Header().Set("Content-Type", "text/html")
 				card := templates.CategoryCardOnly(*updatedCategory, categories)
-				_ = card.Render(w)
+				if err := card.Render(w); err != nil {
+					log.Printf("Error rendering category card: %v", err)
+					http.Error(w, "Internal server error", http.StatusInternalServerError)
+					return
+				}
 			} else {
 				http.Error(w, "Category not found", http.StatusNotFound)
 			}
@@ -1060,7 +1096,11 @@ func (s *Server) rulesPageHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	page := templates.RulesPage(rules, categories)
-	_ = templates.BaseLayoutWithAuth("Rules - Budget App", true, page).Render(w)
+	if err := templates.BaseLayoutWithAuth("Rules - Budget App", true, page).Render(w); err != nil {
+		log.Printf("Error rendering rules page: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
 }
 
 func (s *Server) createRuleHandler(w http.ResponseWriter, r *http.Request) {
@@ -1168,9 +1208,15 @@ func (s *Server) createRuleHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Type", "text/html")
 		if updatedCount > 0 {
-			w.Write([]byte(`<div id="rule-banner" class="alert alert-success position-fixed top-0 start-50 translate-middle-x mt-3" style="z-index:2000; min-width:300px; text-align:center;">Updated ` + strconv.Itoa(updatedCount) + ` transactions</div><script>setTimeout(function(){ var b=document.getElementById('rule-banner'); if(b){b.remove();}}, 3500);</script>`))
+			if _, err := w.Write([]byte(`<div id="rule-banner" class="alert alert-success position-fixed top-0 start-50 translate-middle-x mt-3" style="z-index:2000; min-width:300px; text-align:center;">Updated ` + strconv.Itoa(updatedCount) + ` transactions</div><script>setTimeout(function(){ var b=document.getElementById('rule-banner'); if(b){b.remove();}}, 3500);</script>`)); err != nil {
+				log.Printf("Error writing rule banner: %v", err)
+			}
 		}
-		templates.RenderRulesList(w, rules, categories)
+		if err := templates.RenderRulesList(w, rules, categories); err != nil {
+			log.Printf("Error rendering rules list: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
 	} else {
 		http.Redirect(w, r, "/rules/", http.StatusSeeOther)
 	}
@@ -1262,23 +1308,7 @@ func (s *Server) updateRuleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if isHTMX(r) {
-		// Return updated rules list
-		rules, err := s.store.GetRulesByAccount(account.ID)
-		if err != nil {
-			http.Error(w, "Failed to load rules", http.StatusInternalServerError)
-			return
-		}
-		categories, err := s.store.GetCategoriesByAccount(account.ID)
-		if err != nil {
-			http.Error(w, "Failed to load categories", http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "text/html")
-		templates.RenderRulesList(w, rules, categories)
-	} else {
-		http.Redirect(w, r, "/rules/", http.StatusSeeOther)
-	}
+	s.renderRulesListResponse(w, r, account)
 }
 
 func (s *Server) deleteRuleHandler(w http.ResponseWriter, r *http.Request) {
@@ -1300,23 +1330,7 @@ func (s *Server) deleteRuleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if isHTMX(r) {
-		// Return updated rules list
-		rules, err := s.store.GetRulesByAccount(account.ID)
-		if err != nil {
-			http.Error(w, "Failed to load rules", http.StatusInternalServerError)
-			return
-		}
-		categories, err := s.store.GetCategoriesByAccount(account.ID)
-		if err != nil {
-			http.Error(w, "Failed to load categories", http.StatusInternalServerError)
-			return
-		}
-		w.Header().Set("Content-Type", "text/html")
-		templates.RenderRulesList(w, rules, categories)
-	} else {
-		http.Redirect(w, r, "/rules/", http.StatusSeeOther)
-	}
+	s.renderRulesListResponse(w, r, account)
 }
 
 func (s *Server) toggleRuleHandler(w http.ResponseWriter, r *http.Request) {
@@ -1367,7 +1381,11 @@ func (s *Server) toggleRuleHandler(w http.ResponseWriter, r *http.Request) {
 
 		w.Header().Set("Content-Type", "text/html")
 		// Return only the updated rule card
-		templates.RuleCard(*updatedRule, categories).Render(w)
+		if err := templates.RuleCard(*updatedRule, categories).Render(w); err != nil {
+			log.Printf("Error rendering rule card: %v", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
 	} else {
 		http.Redirect(w, r, "/rules/", http.StatusSeeOther)
 	}
@@ -1416,7 +1434,7 @@ func (s *Server) editRuleHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 
 	// Render the edit form
-	g.El("form",
+	form := g.El("form",
 		g.Attr("hx-put", "/rules/"+strconv.Itoa(rule.ID)),
 		g.Attr("hx-target", "#rules-list"),
 		g.Attr("hx-swap", "outerHTML"),
@@ -1451,5 +1469,10 @@ func (s *Server) editRuleHandler(w http.ResponseWriter, r *http.Request) {
 				container.insertBefore(clone, container.lastElementChild);
 			};
 		`)),
-	).Render(w)
+	)
+	if err := form.Render(w); err != nil {
+		log.Printf("Error rendering rule edit form: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
 }

--- a/templates/layout.go
+++ b/templates/layout.go
@@ -5,6 +5,98 @@ import (
 	"github.com/maragudk/gomponents/html"
 )
 
+// navigationSection creates the navigation menu items
+func navigationSection(isAuthenticated bool) g.Node {
+	return html.Ul(
+		html.Class("nav flex-column"),
+		html.Li(
+			html.Class("nav-item"),
+			html.A(
+				html.Class("nav-link"),
+				html.Href("/"),
+				g.Text("🏠 Home"),
+			),
+		),
+		html.Li(
+			html.Class("nav-item"),
+			html.A(
+				html.Class("nav-link"),
+				html.Href("/about"),
+				g.Text("ℹ️ About"),
+			),
+		),
+		g.Group(func() []g.Node {
+			if isAuthenticated {
+				return []g.Node{
+					html.Li(
+						html.Class("nav-item"),
+						html.A(
+							html.Class("nav-link"),
+							html.Href("/categories/"),
+							g.Text("📂 Categories"),
+						),
+					),
+					html.Li(
+						html.Class("nav-item"),
+						html.A(
+							html.Class("nav-link"),
+							html.Href("/transactions/"),
+							g.Text("💸 Transactions"),
+						),
+					),
+					html.Li(
+						html.Class("nav-item"),
+						html.A(
+							html.Class("nav-link"),
+							html.Href("/rules/"),
+							g.Text("🧩 Rules"),
+						),
+					),
+				}
+			}
+			return nil
+		}()),
+	)
+}
+
+// authenticationSection creates the authentication section
+func authenticationSection(isAuthenticated bool, formID string) g.Node {
+	return html.Div(
+		html.Class("border-top pt-3"),
+		html.H6(
+			html.Class("text-muted mb-3"),
+			g.Text("Account"),
+		),
+		g.Group(func() []g.Node {
+			if isAuthenticated {
+				return []g.Node{
+					g.El("form",
+						html.Action("/auth/logout"),
+						html.Method("POST"),
+						html.Class(""),
+						html.ID(formID),
+						html.Button(
+							html.Class("btn btn-outline-danger btn-sm w-100"),
+							html.Type("submit"),
+							g.Text("Logout"),
+						),
+					),
+				}
+			} else {
+				return []g.Node{
+					html.Button(
+						html.Class("btn btn-primary btn-sm w-100 mb-2"),
+						html.Type("button"),
+						html.DataAttr("bs-toggle", "modal"),
+						html.DataAttr("bs-target", "#authModal"),
+						g.Text("Login / Register"),
+					),
+				}
+			}
+		}()),
+	)
+}
+
 // BaseLayoutWithAuth creates the base layout with authentication-aware content
 func BaseLayoutWithAuth(title string, isAuthenticated bool, content ...g.Node) g.Node {
 	return html.Doctype(
@@ -82,95 +174,11 @@ func BaseLayoutWithAuth(title string, isAuthenticated bool, content ...g.Node) g
 											html.Class("text-muted mb-3"),
 											g.Text("Navigation"),
 										),
-										html.Ul(
-											html.Class("nav flex-column"),
-											html.Li(
-												html.Class("nav-item"),
-												html.A(
-													html.Class("nav-link"),
-													html.Href("/"),
-													g.Text("🏠 Home"),
-												),
-											),
-											html.Li(
-												html.Class("nav-item"),
-												html.A(
-													html.Class("nav-link"),
-													html.Href("/about"),
-													g.Text("ℹ️ About"),
-												),
-											),
-											g.Group(func() []g.Node {
-												if isAuthenticated {
-													return []g.Node{
-														html.Li(
-															html.Class("nav-item"),
-															html.A(
-																html.Class("nav-link"),
-																html.Href("/categories/"),
-																g.Text("📂 Categories"),
-															),
-														),
-														html.Li(
-															html.Class("nav-item"),
-															html.A(
-																html.Class("nav-link"),
-																html.Href("/transactions/"),
-																g.Text("💸 Transactions"),
-															),
-														),
-														html.Li(
-															html.Class("nav-item"),
-															html.A(
-																html.Class("nav-link"),
-																html.Href("/rules/"),
-																g.Text("🧩 Rules"),
-															),
-														),
-													}
-												}
-												return nil
-											}()),
-										),
+										navigationSection(isAuthenticated),
 									),
 
 									// Authentication section
-									html.Div(
-										html.Class("border-top pt-3"),
-										html.H6(
-											html.Class("text-muted mb-3"),
-											g.Text("Account"),
-										),
-
-										// Conditional rendering for sidebar
-										g.Group(func() []g.Node {
-											if isAuthenticated {
-												return []g.Node{
-													g.El("form",
-														html.Action("/auth/logout"),
-														html.Method("POST"),
-														html.Class(""),
-														html.ID("logout-form"),
-														html.Button(
-															html.Class("btn btn-outline-danger btn-sm w-100"),
-															html.Type("submit"),
-															g.Text("Logout"),
-														),
-													),
-												}
-											} else {
-												return []g.Node{
-													html.Button(
-														html.Class("btn btn-primary btn-sm w-100 mb-2"),
-														html.Type("button"),
-														html.DataAttr("bs-toggle", "modal"),
-														html.DataAttr("bs-target", "#authModal"),
-														g.Text("Login / Register"),
-													),
-												}
-											}
-										}()),
-									),
+									authenticationSection(isAuthenticated, "logout-form"),
 								),
 							),
 						),
@@ -222,95 +230,11 @@ func BaseLayoutWithAuth(title string, isAuthenticated bool, content ...g.Node) g
 								html.Class("text-muted mb-3"),
 								g.Text("Navigation"),
 							),
-							html.Ul(
-								html.Class("nav flex-column"),
-								html.Li(
-									html.Class("nav-item"),
-									html.A(
-										html.Class("nav-link"),
-										html.Href("/"),
-										g.Text("🏠 Home"),
-									),
-								),
-								html.Li(
-									html.Class("nav-item"),
-									html.A(
-										html.Class("nav-link"),
-										html.Href("/about"),
-										g.Text("ℹ️ About"),
-									),
-								),
-								g.Group(func() []g.Node {
-									if isAuthenticated {
-										return []g.Node{
-											html.Li(
-												html.Class("nav-item"),
-												html.A(
-													html.Class("nav-link"),
-													html.Href("/categories/"),
-													g.Text("📂 Categories"),
-												),
-											),
-											html.Li(
-												html.Class("nav-item"),
-												html.A(
-													html.Class("nav-link"),
-													html.Href("/transactions/"),
-													g.Text("💸 Transactions"),
-												),
-											),
-											html.Li(
-												html.Class("nav-item"),
-												html.A(
-													html.Class("nav-link"),
-													html.Href("/rules/"),
-													g.Text("🧩 Rules"),
-												),
-											),
-										}
-									}
-									return nil
-								}()),
-							),
+							navigationSection(isAuthenticated),
 						),
 
 						// Authentication section
-						html.Div(
-							html.Class("border-top pt-3"),
-							html.H6(
-								html.Class("text-muted mb-3"),
-								g.Text("Account"),
-							),
-
-							// Conditional rendering for offcanvas
-							g.Group(func() []g.Node {
-								if isAuthenticated {
-									return []g.Node{
-										g.El("form",
-											html.Action("/auth/logout"),
-											html.Method("POST"),
-											html.Class(""),
-											html.ID("logout-form-mobile"),
-											html.Button(
-												html.Class("btn btn-outline-danger btn-sm w-100"),
-												html.Type("submit"),
-												g.Text("Logout"),
-											),
-										),
-									}
-								} else {
-									return []g.Node{
-										html.Button(
-											html.Class("btn btn-primary btn-sm w-100 mb-2"),
-											html.Type("button"),
-											html.DataAttr("bs-toggle", "modal"),
-											html.DataAttr("bs-target", "#authModal"),
-											g.Text("Login / Register"),
-										),
-									}
-								}
-							}()),
-						),
+						authenticationSection(isAuthenticated, "logout-form-mobile"),
 					),
 				),
 

--- a/templates/pages.go
+++ b/templates/pages.go
@@ -523,8 +523,9 @@ func TransactionsPage(transactions []data.Transaction, categories []data.Categor
 					html.Class("list-group"),
 					g.Group(func() []g.Node {
 						var rows []g.Node
-						for _, t := range transactions {
-							rows = append(rows, TransactionCardWithModalSelectable(&t, categories, ""))
+						for i := range transactions {
+							t := &transactions[i]
+							rows = append(rows, TransactionCardWithModalSelectable(t, categories, ""))
 						}
 						return rows
 					}()),
@@ -868,8 +869,9 @@ func RenderTransactionListWithSelectableCards(w io.Writer, txs []data.Transactio
 		html.Class("list-group"),
 		g.Group(func() []g.Node {
 			var rows []g.Node
-			for _, t := range txs {
-				rows = append(rows, TransactionCardWithModalSelectable(&t, cats, ""))
+			for i := range txs {
+				t := &txs[i]
+				rows = append(rows, TransactionCardWithModalSelectable(t, cats, ""))
 			}
 			return rows
 		}()),
@@ -905,7 +907,7 @@ func CategoriesHeaderSection() g.Node {
 }
 
 // CategoriesDirectoryNavigation renders the breadcrumbs and category list
-func CategoriesDirectoryNavigation(visibleCategories []data.Category, allCategories []data.Category, currentParent *data.Category, breadcrumb []data.Category) g.Node {
+func CategoriesDirectoryNavigation(visibleCategories, allCategories []data.Category, currentParent *data.Category, breadcrumb []data.Category) g.Node {
 	return html.Div(
 		html.ID("categories-directory"),
 		html.Class("col-12 col-md-8 px-2 mx-auto"),
@@ -1078,7 +1080,7 @@ func AddCategoryModal(allCategories []data.Category, currentParentID *int) g.Nod
 	return addCategoryModal(allCategories, currentParentID)
 }
 
-func CategoriesDirectoryContent(visibleCategories []data.Category, allCategories []data.Category, currentParent *data.Category, breadcrumb []data.Category) g.Node {
+func CategoriesDirectoryContent(visibleCategories, allCategories []data.Category, currentParent *data.Category, breadcrumb []data.Category) g.Node {
 	var currentParentID *int
 	if currentParent != nil {
 		currentParentID = &currentParent.ID
@@ -1091,7 +1093,7 @@ func CategoriesDirectoryContent(visibleCategories []data.Category, allCategories
 	})
 }
 
-func CategoriesDirectoryPage(visibleCategories []data.Category, allCategories []data.Category, currentParent *data.Category, breadcrumb []data.Category) g.Node {
+func CategoriesDirectoryPage(visibleCategories, allCategories []data.Category, currentParent *data.Category, breadcrumb []data.Category) g.Node {
 	var currentParentID *int
 	if currentParent != nil {
 		currentParentID = &currentParent.ID
@@ -1167,8 +1169,9 @@ func RulesPage(rules []data.Rule, categories []data.Category) g.Node {
 				html.Class("list-group"),
 				g.Group(func() []g.Node {
 					var rows []g.Node
-					for _, rule := range rules {
-						rows = append(rows, RuleCard(&rule, categories))
+					for i := range rules {
+						rule := &rules[i]
+						rows = append(rows, RuleCard(rule, categories))
 					}
 					return rows
 				}()),
@@ -1717,8 +1720,9 @@ func RenderRulesList(w io.Writer, rules []data.Rule, categories []data.Category)
 		html.Class("list-group"),
 		g.Group(func() []g.Node {
 			var rows []g.Node
-			for _, rule := range rules {
-				rows = append(rows, RuleCard(&rule, categories))
+			for i := range rules {
+				rule := &rules[i]
+				rows = append(rows, RuleCard(rule, categories))
 			}
 			return rows
 		}()),
@@ -1726,7 +1730,7 @@ func RenderRulesList(w io.Writer, rules []data.Rule, categories []data.Category)
 }
 
 // CategoryBootstrapDropdown renders a hierarchical category dropdown using Bootstrap dropdowns
-func CategoryBootstrapDropdown(categories []data.Category, selectName, selectID string, selectedID *int, currentNodeID *int, showCurrent bool, disableDescendantsOf *int) g.Node {
+func CategoryBootstrapDropdown(categories []data.Category, selectName, selectID string, selectedID, currentNodeID *int, showCurrent bool, disableDescendantsOf *int) g.Node {
 	flat := flattenCategories(categories, nil, 0)
 	descendants := getDescendantsIfNeeded(categories, disableDescendantsOf)
 	selectedValue, selectedDisplayName := getSelectedCategoryInfo(flat, selectedID)
@@ -1750,12 +1754,12 @@ func getDescendantsIfNeeded(categories []data.Category, disableDescendantsOf *in
 }
 
 // getSelectedCategoryInfo gets the selected category value and display name
-func getSelectedCategoryInfo(flat []flattenedCategory, selectedID *int) (string, string) {
+func getSelectedCategoryInfo(flat []flattenedCategory, selectedID *int) (selectedValue, selectedDisplayName string) {
 	if selectedID == nil {
 		return "", "None (top-level)"
 	}
 
-	selectedValue := strconv.Itoa(*selectedID)
+	selectedValue = strconv.Itoa(*selectedID)
 	for _, item := range flat {
 		if item.Cat.ID == *selectedID {
 			return selectedValue, item.Cat.Name
@@ -1765,7 +1769,7 @@ func getSelectedCategoryInfo(flat []flattenedCategory, selectedID *int) (string,
 }
 
 // escapeForJavaScript escapes strings for JavaScript
-func escapeForJavaScript(selectedValue, selectedDisplayName string) (string, string) {
+func escapeForJavaScript(selectedValue, selectedDisplayName string) (escapedValue, escapedDisplay string) {
 	return strings.ReplaceAll(selectedValue, "'", "\\'"), strings.ReplaceAll(selectedDisplayName, "'", "\\'")
 }
 
@@ -1862,12 +1866,12 @@ func buildCategoryOption(item *flattenedCategory, descendants map[int]bool, curr
 }
 
 // buildIndentation builds indentation style and text
-func buildIndentation(level int) (string, string) {
+func buildIndentation(level int) (indentStyle, indentText string) {
 	if level == 0 {
 		return "", ""
 	}
-	indentStyle := fmt.Sprintf("padding-left: %dpx;", level*20)
-	indentText := strings.Repeat("  ", level) + "└─ "
+	indentStyle = fmt.Sprintf("padding-left: %dpx;", level*20)
+	indentText = strings.Repeat("  ", level) + "└─ "
 	return indentStyle, indentText
 }
 

--- a/templates/pages.go
+++ b/templates/pages.go
@@ -16,6 +16,12 @@ const (
 	uncategorizedCategory = "Uncategorized"
 )
 
+// flattenedCategory represents a category with its hierarchy level
+type flattenedCategory struct {
+	Cat   data.Category
+	Level int
+}
+
 // addCategoryModal creates the add category modal
 func addCategoryModal(categories []data.Category, currentParentID *int) g.Node {
 	return html.Div(
@@ -323,14 +329,8 @@ var treeCSS = g.El("style", g.Raw(`
 `))
 
 // flattenCategories returns a flat list of categories in parent-child order with their level, sorting children by name
-func flattenCategories(categories []data.Category, parentID *int, level int) []struct {
-	Cat   data.Category
-	Level int
-} {
-	var result []struct {
-		Cat   data.Category
-		Level int
-	}
+func flattenCategories(categories []data.Category, parentID *int, level int) []flattenedCategory {
+	var result []flattenedCategory
 	// Collect children
 	var children []data.Category
 	for _, cat := range categories {
@@ -343,10 +343,7 @@ func flattenCategories(categories []data.Category, parentID *int, level int) []s
 		return children[i].Name < children[j].Name
 	})
 	for _, cat := range children {
-		result = append(result, struct {
-			Cat   data.Category
-			Level int
-		}{cat, level})
+		result = append(result, flattenedCategory{cat, level})
 		result = append(result, flattenCategories(categories, &cat.ID, level+1)...)
 	}
 	return result
@@ -527,7 +524,7 @@ func TransactionsPage(transactions []data.Transaction, categories []data.Categor
 					g.Group(func() []g.Node {
 						var rows []g.Node
 						for _, t := range transactions {
-							rows = append(rows, TransactionCardWithModalSelectable(t, categories, ""))
+							rows = append(rows, TransactionCardWithModalSelectable(&t, categories, ""))
 						}
 						return rows
 					}()),
@@ -635,7 +632,7 @@ document.addEventListener('htmx:afterRequest', function() {
 }
 
 // TransactionCardWithModal renders a single transaction card and its modal for editing
-func TransactionCardWithModal(t data.Transaction, categories []data.Category, modalErrMsg string) g.Node {
+func TransactionCardWithModal(t *data.Transaction, categories []data.Category, modalErrMsg string) g.Node {
 	modalID := "editTransactionModal-" + strconv.Itoa(t.ID)
 	cardID := "transaction-card-" + strconv.Itoa(t.ID)
 	// Find category name
@@ -788,7 +785,7 @@ func TransactionCardWithModal(t data.Transaction, categories []data.Category, mo
 }
 
 // TransactionCardWithModalSelectable renders a single transaction card and its modal for editing
-func TransactionCardWithModalSelectable(t data.Transaction, categories []data.Category, modalErrMsg string) g.Node {
+func TransactionCardWithModalSelectable(t *data.Transaction, categories []data.Category, modalErrMsg string) g.Node {
 	cardID := "transaction-card-" + strconv.Itoa(t.ID)
 	// Find category name
 	var categoryName string
@@ -872,7 +869,7 @@ func RenderTransactionListWithSelectableCards(w io.Writer, txs []data.Transactio
 		g.Group(func() []g.Node {
 			var rows []g.Node
 			for _, t := range txs {
-				rows = append(rows, TransactionCardWithModalSelectable(t, cats, ""))
+				rows = append(rows, TransactionCardWithModalSelectable(&t, cats, ""))
 			}
 			return rows
 		}()),
@@ -972,7 +969,7 @@ func CategoriesDirectoryNavigation(visibleCategories []data.Category, allCategor
 				for _, c := range visibleCategories {
 					cards = append(cards, html.Div(
 						html.Class("col"),
-						CategoryCard(c, allCategories),
+						CategoryCard(&c, allCategories),
 					))
 				}
 				return cards
@@ -982,7 +979,7 @@ func CategoriesDirectoryNavigation(visibleCategories []data.Category, allCategor
 }
 
 // CategoryCardOnly renders just the category card without the modal
-func CategoryCardOnly(c data.Category, allCategories []data.Category) g.Node {
+func CategoryCardOnly(c *data.Category, allCategories []data.Category) g.Node {
 	return html.Div(
 		html.ID("category-card-"+strconv.Itoa(c.ID)),
 		html.Class("card"),
@@ -1020,7 +1017,7 @@ func CategoryCardOnly(c data.Category, allCategories []data.Category) g.Node {
 }
 
 // CategoryCard renders a single category card
-func CategoryCard(c data.Category, allCategories []data.Category) g.Node {
+func CategoryCard(c *data.Category, allCategories []data.Category) g.Node {
 	return g.Group([]g.Node{
 		CategoryCardOnly(c, allCategories),
 		// Edit Category Modal
@@ -1171,7 +1168,7 @@ func RulesPage(rules []data.Rule, categories []data.Category) g.Node {
 				g.Group(func() []g.Node {
 					var rows []g.Node
 					for _, rule := range rules {
-						rows = append(rows, RuleCard(rule, categories))
+						rows = append(rows, RuleCard(&rule, categories))
 					}
 					return rows
 				}()),
@@ -1248,7 +1245,7 @@ func RulesPage(rules []data.Rule, categories []data.Category) g.Node {
 }
 
 // RuleCard renders a single rule card
-func RuleCard(rule data.Rule, categories []data.Category) g.Node {
+func RuleCard(rule *data.Rule, categories []data.Category) g.Node {
 	return html.Div(
 		html.Class("card mb-3"),
 		g.Attr("data-rule-id", strconv.Itoa(rule.ID)),
@@ -1721,7 +1718,7 @@ func RenderRulesList(w io.Writer, rules []data.Rule, categories []data.Category)
 		g.Group(func() []g.Node {
 			var rows []g.Node
 			for _, rule := range rules {
-				rows = append(rows, RuleCard(rule, categories))
+				rows = append(rows, RuleCard(&rule, categories))
 			}
 			return rows
 		}()),
@@ -1731,147 +1728,197 @@ func RenderRulesList(w io.Writer, rules []data.Rule, categories []data.Category)
 // CategoryBootstrapDropdown renders a hierarchical category dropdown using Bootstrap dropdowns
 func CategoryBootstrapDropdown(categories []data.Category, selectName, selectID string, selectedID *int, currentNodeID *int, showCurrent bool, disableDescendantsOf *int) g.Node {
 	flat := flattenCategories(categories, nil, 0)
-	var descendants map[int]bool
-	if disableDescendantsOf != nil {
-		descendants = getDescendants(categories, *disableDescendantsOf)
-	}
-
-	// Find the selected category name without indentation for display
-	var selectedDisplayName string
-	var selectedValue string
-	if selectedID != nil {
-		selectedValue = strconv.Itoa(*selectedID)
-		for _, item := range flat {
-			if item.Cat.ID == *selectedID {
-				selectedDisplayName = item.Cat.Name
-				break
-			}
-		}
-	} else {
-		selectedValue = ""
-		selectedDisplayName = "None (top-level)"
-	}
-
-	// Escape strings for JavaScript
-	escapedSelectedValue := strings.ReplaceAll(selectedValue, "'", "\\'")
-	escapedSelectedDisplay := strings.ReplaceAll(selectedDisplayName, "'", "\\'")
+	descendants := getDescendantsIfNeeded(categories, disableDescendantsOf)
+	selectedValue, selectedDisplayName := getSelectedCategoryInfo(flat, selectedID)
+	escapedSelectedValue, escapedSelectedDisplay := escapeForJavaScript(selectedValue, selectedDisplayName)
 
 	return html.Div(
 		html.Class("dropdown"),
-		g.Attr("x-data", fmt.Sprintf(`{
-			selectedValue: '%s',
-			selectedDisplay: '%s',
-			selectCategory(value, display) {
-				this.selectedValue = value;
-				this.selectedDisplay = display;
-			},
-			init() {
-				// Watch for form reset events and sync Alpine state
-				this.$watch('selectedValue', (value) => {
-					const hiddenInput = this.$el.querySelector('input[name="%s"]');
-					if (hiddenInput) {
-						hiddenInput.value = value;
-					}
-				});
-			}
-		}`, escapedSelectedValue, escapedSelectedDisplay, selectName)),
-		// Dropdown button
-		html.Button(
-			html.Class("btn border dropdown-toggle w-100 d-flex justify-content-between align-items-center"),
-			html.Type("button"),
-			html.ID(selectID),
-			html.DataAttr("bs-toggle", "dropdown"),
-			html.DataAttr("bs-auto-close", "true"),
-			g.Attr("x-text", "selectedDisplay"),
-		),
-		// Dropdown menu
-		html.Ul(
-			html.Class("dropdown-menu w-100"),
-			g.Attr("style", "max-height: 300px; overflow-y: auto;"),
-			// None option
-			html.Li(
-				html.A(
-					html.Class("dropdown-item"),
-					html.Href("#"),
-					g.Attr("x-on:click", "selectCategory('', 'None (top-level)'); $event.preventDefault()"),
-					g.Text("None (top-level)"),
-				),
-			),
-			// Divider
-			html.Li(html.Hr(html.Class("dropdown-divider"))),
-			// Category options
-			g.Group(func() []g.Node {
-				var items []g.Node
-				for _, item := range flat {
-					cat := item.Cat
+		g.Attr("x-data", buildAlpineJSData(escapedSelectedValue, escapedSelectedDisplay, selectName)),
+		buildDropdownButton(selectID),
+		buildDropdownMenu(flat, descendants, currentNodeID, showCurrent),
+		buildHiddenInput(selectName),
+	)
+}
 
-					// Create proper indentation
-					var indentStyle string
-					var indentText string
-					if item.Level > 0 {
-						// Use inline styles for reliable indentation
-						indentStyle = fmt.Sprintf("padding-left: %dpx;", item.Level*20)
-						// Add visual tree indicators
-						indentText = strings.Repeat("  ", item.Level) + "└─ "
-					}
+// getDescendantsIfNeeded gets descendants map if needed
+func getDescendantsIfNeeded(categories []data.Category, disableDescendantsOf *int) map[int]bool {
+	if disableDescendantsOf == nil {
+		return nil
+	}
+	return getDescendants(categories, *disableDescendantsOf)
+}
 
-					// Check if this category should be disabled
-					isDisabled := false
-					if showCurrent && currentNodeID != nil && cat.ID == *currentNodeID {
-						isDisabled = true
-					}
-					if descendants != nil && descendants[cat.ID] {
-						isDisabled = true
-					}
+// getSelectedCategoryInfo gets the selected category value and display name
+func getSelectedCategoryInfo(flat []flattenedCategory, selectedID *int) (string, string) {
+	if selectedID == nil {
+		return "", "None (top-level)"
+	}
 
-					itemClass := "dropdown-item"
-					if isDisabled {
-						itemClass += " disabled"
-					}
+	selectedValue := strconv.Itoa(*selectedID)
+	for _, item := range flat {
+		if item.Cat.ID == *selectedID {
+			return selectedValue, item.Cat.Name
+		}
+	}
+	return selectedValue, ""
+}
 
-					// Add visual styling for different levels
-					if item.Level == 0 {
-						itemClass += " fw-semibold" // Top-level categories are bold
-					} else {
-						itemClass += " text-muted" // Sub-categories are muted
-					}
+// escapeForJavaScript escapes strings for JavaScript
+func escapeForJavaScript(selectedValue, selectedDisplayName string) (string, string) {
+	return strings.ReplaceAll(selectedValue, "'", "\\'"), strings.ReplaceAll(selectedDisplayName, "'", "\\'")
+}
 
-					// Create the click handler for this category
-					clickHandler := ""
-					if !isDisabled {
-						// Escape the category name for JavaScript
-						escapedName := strings.ReplaceAll(cat.Name, "'", "\\'")
-						clickHandler = fmt.Sprintf("selectCategory('%d', '%s'); $event.preventDefault()", cat.ID, escapedName)
-					}
-
-					items = append(items, html.Li(
-						html.A(
-							html.Class(itemClass),
-							g.Attr("style", indentStyle),
-							html.Href("#"),
-							func() g.Node {
-								if clickHandler != "" {
-									return g.Attr("x-on:click", clickHandler)
-								}
-								return nil
-							}(),
-							g.Text(indentText+func() string {
-								if showCurrent && currentNodeID != nil && cat.ID == *currentNodeID {
-									return cat.Name + " ★"
-								}
-								return cat.Name
-							}()),
-						),
-					))
+// buildAlpineJSData builds the Alpine.js data attribute
+func buildAlpineJSData(escapedSelectedValue, escapedSelectedDisplay, selectName string) string {
+	return fmt.Sprintf(`{
+		selectedValue: '%s',
+		selectedDisplay: '%s',
+		selectCategory(value, display) {
+			this.selectedValue = value;
+			this.selectedDisplay = display;
+		},
+		init() {
+			// Watch for form reset events and sync Alpine state
+			this.$watch('selectedValue', (value) => {
+				const hiddenInput = this.$el.querySelector('input[name="%s"]');
+				if (hiddenInput) {
+					hiddenInput.value = value;
 				}
-				return items
-			}()),
+			});
+		}
+	}`, escapedSelectedValue, escapedSelectedDisplay, selectName)
+}
+
+// buildDropdownButton builds the dropdown button
+func buildDropdownButton(selectID string) g.Node {
+	return html.Button(
+		html.Class("btn border dropdown-toggle w-100 d-flex justify-content-between align-items-center"),
+		html.Type("button"),
+		html.ID(selectID),
+		html.DataAttr("bs-toggle", "dropdown"),
+		html.DataAttr("bs-auto-close", "true"),
+		g.Attr("x-text", "selectedDisplay"),
+	)
+}
+
+// buildDropdownMenu builds the dropdown menu
+func buildDropdownMenu(flat []flattenedCategory, descendants map[int]bool, currentNodeID *int, showCurrent bool) g.Node {
+	return html.Ul(
+		html.Class("dropdown-menu w-100"),
+		g.Attr("style", "max-height: 300px; overflow-y: auto;"),
+		buildNoneOption(),
+		html.Li(html.Hr(html.Class("dropdown-divider"))),
+		buildCategoryOptions(flat, descendants, currentNodeID, showCurrent),
+	)
+}
+
+// buildNoneOption builds the "None" option
+func buildNoneOption() g.Node {
+	return html.Li(
+		html.A(
+			html.Class("dropdown-item"),
+			html.Href("#"),
+			g.Attr("x-on:click", "selectCategory('', 'None (top-level)'); $event.preventDefault()"),
+			g.Text("None (top-level)"),
 		),
-		// Hidden input to store the selected value
-		html.Input(
-			html.Type("hidden"),
-			html.Name(selectName),
-			g.Attr("x-model", "selectedValue"),
+	)
+}
+
+// buildCategoryOptions builds the category options
+func buildCategoryOptions(flat []flattenedCategory, descendants map[int]bool, currentNodeID *int, showCurrent bool) g.Node {
+	return g.Group(func() []g.Node {
+		var items []g.Node
+		for _, item := range flat {
+			items = append(items, buildCategoryOption(&item, descendants, currentNodeID, showCurrent))
+		}
+		return items
+	}())
+}
+
+// buildCategoryOption builds a single category option
+func buildCategoryOption(item *flattenedCategory, descendants map[int]bool, currentNodeID *int, showCurrent bool) g.Node {
+	cat := item.Cat
+	indentStyle, indentText := buildIndentation(item.Level)
+	isDisabled := isCategoryDisabled(&cat, descendants, currentNodeID, showCurrent)
+	itemClass := buildItemClass(item.Level, isDisabled)
+	clickHandler := buildClickHandler(&cat, isDisabled)
+	displayText := buildDisplayText(&cat, currentNodeID, showCurrent, indentText)
+
+	return html.Li(
+		html.A(
+			html.Class(itemClass),
+			g.Attr("style", indentStyle),
+			html.Href("#"),
+			func() g.Node {
+				if clickHandler != "" {
+					return g.Attr("x-on:click", clickHandler)
+				}
+				return nil
+			}(),
+			g.Text(displayText),
 		),
+	)
+}
+
+// buildIndentation builds indentation style and text
+func buildIndentation(level int) (string, string) {
+	if level == 0 {
+		return "", ""
+	}
+	indentStyle := fmt.Sprintf("padding-left: %dpx;", level*20)
+	indentText := strings.Repeat("  ", level) + "└─ "
+	return indentStyle, indentText
+}
+
+// isCategoryDisabled checks if a category should be disabled
+func isCategoryDisabled(cat *data.Category, descendants map[int]bool, currentNodeID *int, showCurrent bool) bool {
+	if showCurrent && currentNodeID != nil && cat.ID == *currentNodeID {
+		return true
+	}
+	if descendants != nil && descendants[cat.ID] {
+		return true
+	}
+	return false
+}
+
+// buildItemClass builds the CSS class for a category item
+func buildItemClass(level int, isDisabled bool) string {
+	itemClass := "dropdown-item"
+	if isDisabled {
+		itemClass += " disabled"
+	}
+	if level == 0 {
+		itemClass += " fw-semibold" // Top-level categories are bold
+	} else {
+		itemClass += " text-muted" // Sub-categories are muted
+	}
+	return itemClass
+}
+
+// buildClickHandler builds the click handler for a category
+func buildClickHandler(cat *data.Category, isDisabled bool) string {
+	if isDisabled {
+		return ""
+	}
+	escapedName := strings.ReplaceAll(cat.Name, "'", "\\'")
+	return fmt.Sprintf("selectCategory('%d', '%s'); $event.preventDefault()", cat.ID, escapedName)
+}
+
+// buildDisplayText builds the display text for a category
+func buildDisplayText(cat *data.Category, currentNodeID *int, showCurrent bool, indentText string) string {
+	baseText := cat.Name
+	if showCurrent && currentNodeID != nil && cat.ID == *currentNodeID {
+		baseText += " ★"
+	}
+	return indentText + baseText
+}
+
+// buildHiddenInput builds the hidden input for the selected value
+func buildHiddenInput(selectName string) g.Node {
+	return html.Input(
+		html.Type("hidden"),
+		html.Name(selectName),
+		g.Attr("x-model", "selectedValue"),
 	)
 }

--- a/templates/pages.go
+++ b/templates/pages.go
@@ -12,6 +12,10 @@ import (
 	"github.com/maragudk/gomponents/html"
 )
 
+const (
+	uncategorizedCategory = "Uncategorized"
+)
+
 func HomePage() g.Node {
 	return g.Group([]g.Node{
 		html.Div(
@@ -235,25 +239,6 @@ func RegisterPage() g.Node {
 			),
 		),
 	)
-}
-
-// Helper to build the breadcrumb path for a category
-func buildCategoryBreadcrumb(c data.Category, categories []data.Category) []string {
-	var path []string
-	current := &c
-	catMap := map[int]*data.Category{}
-	for i := range categories {
-		catMap[categories[i].ID] = &categories[i]
-	}
-	for current != nil {
-		path = append([]string{current.Name}, path...)
-		if current.ParentID != nil {
-			current = catMap[*current.ParentID]
-		} else {
-			current = nil
-		}
-	}
-	return path
 }
 
 // Update CSS for a vertical tree with minimal indentation
@@ -651,7 +636,7 @@ func TransactionCardWithModal(t data.Transaction, categories []data.Category, mo
 	// Find category name
 	var categoryName string
 	if t.CategoryID == nil {
-		categoryName = "Uncategorized"
+		categoryName = uncategorizedCategory
 	} else {
 		for _, c := range categories {
 			if c.ID == *t.CategoryID {
@@ -660,7 +645,7 @@ func TransactionCardWithModal(t data.Transaction, categories []data.Category, mo
 			}
 		}
 		if categoryName == "" {
-			categoryName = "Uncategorized"
+			categoryName = uncategorizedCategory
 		}
 	}
 	return html.Div(
@@ -803,7 +788,7 @@ func TransactionCardWithModalSelectable(t data.Transaction, categories []data.Ca
 	// Find category name
 	var categoryName string
 	if t.CategoryID == nil {
-		categoryName = "Uncategorized"
+		categoryName = uncategorizedCategory
 	} else {
 		for _, c := range categories {
 			if c.ID == *t.CategoryID {
@@ -812,7 +797,7 @@ func TransactionCardWithModalSelectable(t data.Transaction, categories []data.Ca
 			}
 		}
 		if categoryName == "" {
-			categoryName = "Uncategorized"
+			categoryName = uncategorizedCategory
 		}
 	}
 	return html.Div(
@@ -873,12 +858,6 @@ func TransactionCardWithModalSelectable(t data.Transaction, categories []data.Ca
 }
 
 // Helper function for max
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
 
 // Add after TransactionCardWithModalSelectable
 func RenderTransactionListWithSelectableCards(w io.Writer, txs []data.Transaction, cats []data.Category) error {

--- a/templates/pages.go
+++ b/templates/pages.go
@@ -16,6 +16,59 @@ const (
 	uncategorizedCategory = "Uncategorized"
 )
 
+// addCategoryModal creates the add category modal
+func addCategoryModal(categories []data.Category, currentParentID *int) g.Node {
+	return html.Div(
+		html.Class("modal fade"),
+		html.ID("addCategoryModal"),
+		html.DataAttr("tabindex", "-1"),
+		html.DataAttr("aria-labelledby", "addCategoryModalLabel"),
+		html.DataAttr("aria-hidden", "true"),
+		html.Div(
+			html.Class("modal-dialog"),
+			html.Div(
+				html.Class("modal-content"),
+				html.Div(
+					html.Class("modal-header"),
+					html.H5(html.Class("modal-title"), html.ID("addCategoryModalLabel"), g.Text("Add Category")),
+					html.Button(
+						html.Class("btn-close"),
+						html.Type("button"),
+						html.DataAttr("bs-dismiss", "modal"),
+						html.DataAttr("aria-label", "Close"),
+					),
+				),
+				html.Div(
+					html.Class("modal-body"),
+					g.El("form",
+						html.Action("/categories/"),
+						html.Method("POST"),
+						g.Attr("hx-post", "/categories/"),
+						g.Attr("hx-target", "#categories-directory"),
+						g.Attr("hx-swap", "outerHTML"),
+						g.Attr("hx-on::after-request", "if (event.target === this) { bootstrap.Modal.getInstance(document.getElementById('addCategoryModal')).hide(); }"),
+						html.Div(
+							html.Class("mb-3"),
+							html.Label(html.Class("form-label"), html.For("add-name"), g.Text("Name")),
+							html.Input(html.Type("text"), html.Name("name"), html.ID("add-name"), html.Class("form-control"), html.Required()),
+						),
+						html.Div(
+							html.Class("mb-3"),
+							html.Label(html.Class("form-label"), html.For("add-parent"), g.Text("Parent Category")),
+							CategoryBootstrapDropdown(categories, "parent_id", "add-parent", currentParentID, nil, false, nil),
+						),
+						html.Div(
+							html.Class("d-flex justify-content-end gap-2"),
+							html.Button(html.Type("button"), html.Class("btn btn-secondary"), html.DataAttr("bs-dismiss", "modal"), g.Text("Cancel")),
+							html.Button(html.Type("submit"), html.Class("btn btn-primary"), g.Text("Add Category")),
+						),
+					),
+				),
+			),
+		),
+	)
+}
+
 func HomePage() g.Node {
 	return g.Group([]g.Node{
 		html.Div(
@@ -412,55 +465,7 @@ func CategoriesPage(categories []data.Category) g.Node {
 					}()),
 				),
 				// Add Category Modal
-				html.Div(
-					html.Class("modal fade"),
-					html.ID("addCategoryModal"),
-					html.DataAttr("tabindex", "-1"),
-					html.DataAttr("aria-labelledby", "addCategoryModalLabel"),
-					html.DataAttr("aria-hidden", "true"),
-					html.Div(
-						html.Class("modal-dialog"),
-						html.Div(
-							html.Class("modal-content"),
-							html.Div(
-								html.Class("modal-header"),
-								html.H5(html.Class("modal-title"), html.ID("addCategoryModalLabel"), g.Text("Add Category")),
-								html.Button(
-									html.Class("btn-close"),
-									html.Type("button"),
-									html.DataAttr("bs-dismiss", "modal"),
-									html.DataAttr("aria-label", "Close"),
-								),
-							),
-							html.Div(
-								html.Class("modal-body"),
-								g.El("form",
-									html.Action("/categories/"),
-									html.Method("POST"),
-									g.Attr("hx-post", "/categories/"),
-									g.Attr("hx-target", "#categories-directory"),
-									g.Attr("hx-swap", "outerHTML"),
-									g.Attr("hx-on::after-request", "if (event.target === this) { bootstrap.Modal.getInstance(document.getElementById('addCategoryModal')).hide(); }"),
-									html.Div(
-										html.Class("mb-3"),
-										html.Label(html.Class("form-label"), html.For("add-name"), g.Text("Name")),
-										html.Input(html.Type("text"), html.Name("name"), html.ID("add-name"), html.Class("form-control"), html.Required()),
-									),
-									html.Div(
-										html.Class("mb-3"),
-										html.Label(html.Class("form-label"), html.For("add-parent"), g.Text("Parent Category")),
-										CategoryBootstrapDropdown(categories, "parent_id", "add-parent", nil, nil, false, nil),
-									),
-									html.Div(
-										html.Class("d-flex justify-content-end gap-2"),
-										html.Button(html.Type("button"), html.Class("btn btn-secondary"), html.DataAttr("bs-dismiss", "modal"), g.Text("Cancel")),
-										html.Button(html.Type("submit"), html.Class("btn btn-primary"), g.Text("Add Category")),
-									),
-								),
-							),
-						),
-					),
-				),
+				addCategoryModal(categories, nil),
 			),
 		),
 	})
@@ -1073,55 +1078,7 @@ func CategoryCard(c data.Category, allCategories []data.Category) g.Node {
 
 // AddCategoryModal renders the modal for adding a new category
 func AddCategoryModal(allCategories []data.Category, currentParentID *int) g.Node {
-	return html.Div(
-		html.Class("modal fade"),
-		html.ID("addCategoryModal"),
-		html.DataAttr("tabindex", "-1"),
-		html.DataAttr("aria-labelledby", "addCategoryModalLabel"),
-		html.DataAttr("aria-hidden", "true"),
-		html.Div(
-			html.Class("modal-dialog"),
-			html.Div(
-				html.Class("modal-content"),
-				html.Div(
-					html.Class("modal-header"),
-					html.H5(html.Class("modal-title"), html.ID("addCategoryModalLabel"), g.Text("Add Category")),
-					html.Button(
-						html.Class("btn-close"),
-						html.Type("button"),
-						html.DataAttr("bs-dismiss", "modal"),
-						html.DataAttr("aria-label", "Close"),
-					),
-				),
-				html.Div(
-					html.Class("modal-body"),
-					g.El("form",
-						html.Action("/categories/"),
-						html.Method("POST"),
-						g.Attr("hx-post", "/categories/"),
-						g.Attr("hx-target", "#categories-directory"),
-						g.Attr("hx-swap", "outerHTML"),
-						g.Attr("hx-on::after-request", "if (event.target === this) { bootstrap.Modal.getInstance(document.getElementById('addCategoryModal')).hide(); }"),
-						html.Div(
-							html.Class("mb-3"),
-							html.Label(html.Class("form-label"), html.For("add-name"), g.Text("Name")),
-							html.Input(html.Type("text"), html.Name("name"), html.ID("add-name"), html.Class("form-control"), html.Required()),
-						),
-						html.Div(
-							html.Class("mb-3"),
-							html.Label(html.Class("form-label"), html.For("add-parent"), g.Text("Parent Category")),
-							CategoryBootstrapDropdown(allCategories, "parent_id", "add-parent", currentParentID, nil, false, nil),
-						),
-						html.Div(
-							html.Class("d-flex justify-content-end gap-2"),
-							html.Button(html.Type("button"), html.Class("btn btn-secondary"), html.DataAttr("bs-dismiss", "modal"), g.Text("Cancel")),
-							html.Button(html.Type("submit"), html.Class("btn btn-primary"), g.Text("Add Category")),
-						),
-					),
-				),
-			),
-		),
-	)
+	return addCategoryModal(allCategories, currentParentID)
 }
 
 func CategoriesDirectoryContent(visibleCategories []data.Category, allCategories []data.Category, currentParent *data.Category, breadcrumb []data.Category) g.Node {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,8 +34,9 @@ locals {
   
   # Create shorter versions for different resource types
   short_id = substr(local.sanitized_id, 0, 20)  # For database names (40 char limit, but keep shorter)
-  vpc_id = substr(local.sanitized_id, 0, 22)    # For VPC names (32 char limit, but need space for "budget-vpc-" prefix)
+  vpc_id = substr(local.sanitized_id, 0, 21)    # For VPC names (32 char limit, but need space for "budget-vpc-" prefix)
   app_id = substr(local.sanitized_id, 0, 32)    # For app names (32 char limit)
+  migration_app_id = substr(local.sanitized_id, 0, 21)  # For migration app names (32 char limit, but need space for "-migrations" suffix)
 }
 
 # Reference existing DigitalOcean project
@@ -176,7 +177,7 @@ resource "digitalocean_app" "budget_migrations" {
   # If image tag is same (cache hit), no redeployment needed
 
   spec {
-    name   = "${local.app_id}-migrations"
+    name   = "${local.migration_app_id}-migrations"
     region = var.region
     
     # Enable VPC networking for database access

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,6 +26,18 @@ provider "digitalocean" {
   token = var.do_token
 }
 
+# Local values for sanitized naming
+locals {
+  # Sanitize deployment_id for DigitalOcean naming constraints
+  # Rules: alphanumeric, underscores, dashes only; max 40 chars for DB names, 64 for usernames
+  sanitized_id = replace(replace(replace(var.deployment_id, "/[^a-zA-Z0-9_-]/", "-"), "/^-+|-+$/", ""), "/-+/", "-")
+  
+  # Create shorter versions for different resource types
+  short_id = substr(local.sanitized_id, 0, 20)  # For database names (40 char limit, but keep shorter)
+  vpc_id = substr(local.sanitized_id, 0, 22)    # For VPC names (32 char limit, but need space for "budget-vpc-" prefix)
+  app_id = substr(local.sanitized_id, 0, 32)    # For app names (32 char limit)
+}
+
 # Reference existing DigitalOcean project
 data "digitalocean_project" "budget" {
   name = "budget-develop"
@@ -33,7 +45,7 @@ data "digitalocean_project" "budget" {
 
 # Create VPC for private networking
 resource "digitalocean_vpc" "budget_vpc" {
-  name     = substr("budget-vpc-${var.deployment_id}", 0, 32)  # VPC name limit
+  name     = "budget-vpc-${local.vpc_id}"
   region   = var.region
   ip_range = "172.16.0.0/16"  # Private IP range (avoiding conflicts)
   
@@ -42,7 +54,7 @@ resource "digitalocean_vpc" "budget_vpc" {
 
 # Managed PostgreSQL database with private VPC networking
 resource "digitalocean_database_cluster" "budget_db" {
-  name                 = "budget-db-${var.deployment_id}"
+  name                 = "budget-db-${local.short_id}"
   engine               = "pg"
   version              = "16"
   size                 = "db-s-1vcpu-1gb"  # Cheapest managed DB option
@@ -59,13 +71,13 @@ resource "digitalocean_database_cluster" "budget_db" {
 # Create database within the cluster
 resource "digitalocean_database_db" "budget_database" {
   cluster_id = digitalocean_database_cluster.budget_db.id
-  name       = "budget-${var.deployment_id}"
+  name       = "budget-${local.short_id}"
 }
 
 # Create database user
 resource "digitalocean_database_user" "budget_user" {
   cluster_id = digitalocean_database_cluster.budget_db.id
-  name       = "budget-app-${var.deployment_id}"
+  name       = "budget-app-${local.short_id}"
   
   # Note: Database user password is auto-generated and stable
   # DigitalOcean manages password lifecycle
@@ -164,7 +176,7 @@ resource "digitalocean_app" "budget_migrations" {
   # If image tag is same (cache hit), no redeployment needed
 
   spec {
-    name   = substr("${var.deployment_id}-migrations", 0, 32)  # Trim to 32 chars max
+    name   = "${local.app_id}-migrations"
     region = var.region
     
     # Enable VPC networking for database access
@@ -223,7 +235,7 @@ resource "digitalocean_app" "budget_app" {
   # If image tag is same (cache hit), no redeployment needed
 
   spec {
-    name   = substr(var.deployment_id, 0, 32)  # Trim to 32 chars max
+    name   = local.app_id
     region = var.region
     
     # Enable VPC networking for database access


### PR DESCRIPTION
Fix deploy workflow failure by correcting YAML syntax for the `on` key and configuring reusable workflow permissions.

The deploy workflow was not starting at all because the `on:` key in `deploy.yml` was being interpreted as a boolean `true` by the YAML parser, leading to a malformed workflow definition. Additionally, the `go-checks` reusable workflow required explicit inputs and permissions to execute correctly. Non-existent step references were also cleaned up.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce076bb7-1904-4c13-80da-0b4859992934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce076bb7-1904-4c13-80da-0b4859992934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

